### PR TITLE
feat: Implement accordion for appliance categories and rename default

### DIFF
--- a/backend/backend.py
+++ b/backend/backend.py
@@ -109,7 +109,7 @@ def get_electrodomesticos_consumos():
 
             # Categorization logic
             appliance_name_lower = str(nombre).strip().lower()
-            category = appliance_to_category_map.get(appliance_name_lower, "Varios")
+            category = appliance_to_category_map.get(appliance_name_lower, "Artículos del Hogar")
 
             appliance_entry = {
                 "name": str(nombre).strip(),

--- a/calculador.js
+++ b/calculador.js
@@ -1334,11 +1334,22 @@ function populateStandardApplianceList(listContainerElement) {
     listContainerElement.innerHTML = '';
 
     Object.keys(electrodomesticosCategorias).forEach(categoria => {
-        const h2 = document.createElement('h2');
-        h2.textContent = categoria;
-        listContainerElement.appendChild(h2);
+        const categoryWrapper = document.createElement('div');
+        categoryWrapper.className = 'acordeon-categoria-wrapper';
+
+        const titleH2 = document.createElement('h2');
+        titleH2.className = 'acordeon-titulo';
+        titleH2.textContent = categoria;
+
+        const iconSpan = document.createElement('span');
+        iconSpan.className = 'acordeon-icono';
+        iconSpan.innerHTML = '&#9660;';
+        titleH2.appendChild(iconSpan);
+
         const itemsDiv = document.createElement('div');
-        itemsDiv.className = 'electrodomesticos-categoria';
+        itemsDiv.className = 'acordeon-items';
+        itemsDiv.style.display = 'none';
+
         electrodomesticosCategorias[categoria].forEach(item => {
             const row = document.createElement('div');
             row.className = 'electrodomestico-row';
@@ -1367,8 +1378,12 @@ function populateStandardApplianceList(listContainerElement) {
             row.appendChild(input);
             itemsDiv.appendChild(row);
         });
-        listContainerElement.appendChild(itemsDiv);
+
+        categoryWrapper.appendChild(titleH2);
+        categoryWrapper.appendChild(itemsDiv);
+        listContainerElement.appendChild(categoryWrapper);
     });
+    initAccordionEventListeners(); // Add this call
     calcularConsumo(); // Initial calculation after populating
 }
 
@@ -1380,12 +1395,21 @@ function populateDetailedApplianceList(listContainerElement) {
     listContainerElement.innerHTML = ''; // Clear previous content
 
     Object.keys(electrodomesticosCategorias).forEach(categoria => {
-        const h2 = document.createElement('h2');
-        h2.textContent = categoria;
-        listContainerElement.appendChild(h2);
+        const categoryWrapper = document.createElement('div');
+        categoryWrapper.className = 'acordeon-categoria-wrapper';
+
+        const titleH2 = document.createElement('h2');
+        titleH2.className = 'acordeon-titulo';
+        titleH2.textContent = categoria;
+
+        const iconSpan = document.createElement('span');
+        iconSpan.className = 'acordeon-icono';
+        iconSpan.innerHTML = '&#9660;';
+        titleH2.appendChild(iconSpan);
 
         const itemsDiv = document.createElement('div');
-        itemsDiv.className = 'electrodomesticos-categoria'; // Reuse existing class if suitable
+        itemsDiv.className = 'acordeon-items';
+        itemsDiv.style.display = 'none';
 
         electrodomesticosCategorias[categoria].forEach(item => {
             const itemName = item.name;
@@ -1462,8 +1486,12 @@ function populateDetailedApplianceList(listContainerElement) {
             row.appendChild(horasInviernoInput);
             itemsDiv.appendChild(row);
         });
-        listContainerElement.appendChild(itemsDiv);
+
+        categoryWrapper.appendChild(titleH2);
+        categoryWrapper.appendChild(itemsDiv);
+        listContainerElement.appendChild(categoryWrapper);
     });
+    initAccordionEventListeners(); // Add this call
 
     const summaryContainer = document.querySelector('#energia-section .energy-summary');
     if (summaryContainer) {
@@ -1473,6 +1501,37 @@ function populateDetailedApplianceList(listContainerElement) {
         if (totalConsumoAnualDisplay) totalConsumoAnualDisplay.value = 'N/A (modo detallado)';
         summaryContainer.style.display = 'flex';
     }
+}
+
+function initAccordionEventListeners() {
+    const accordionTitles = document.querySelectorAll('.acordeon-titulo');
+
+    accordionTitles.forEach(title => {
+        // Check if a listener is already attached to avoid duplicates if called multiple times
+        if (title.dataset.accordionListenerAttached === 'true') {
+            return;
+        }
+        title.dataset.accordionListenerAttached = 'true';
+
+        title.addEventListener('click', () => {
+            const itemsDiv = title.nextElementSibling;
+            const iconSpan = title.querySelector('.acordeon-icono');
+
+            if (itemsDiv && itemsDiv.classList.contains('acordeon-items')) {
+                if (itemsDiv.style.display === 'none' || itemsDiv.style.display === '') {
+                    itemsDiv.style.display = 'block';
+                    title.classList.add('open'); // Add this line
+                    if (iconSpan) iconSpan.innerHTML = '&#9650;'; // Up arrow ▲
+                } else {
+                    itemsDiv.style.display = 'none';
+                    title.classList.remove('open'); // Add this line
+                    if (iconSpan) iconSpan.innerHTML = '&#9660;'; // Down arrow ▼
+                }
+            } else {
+                console.warn('Accordion items div not found or is not the next sibling for:', title);
+            }
+        });
+    });
 }
 
 function calcularConsumo() {

--- a/styles.css
+++ b/styles.css
@@ -1012,3 +1012,56 @@ footer {
     width: 100px; /* Adjust width as needed */
     text-align: right;
 }
+
+/* Accordion Styles */
+.acordeon-categoria-wrapper {
+  margin-bottom: 10px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  overflow: hidden; /* Ensures border-radius is respected by children */
+}
+
+.acordeon-titulo {
+  background-color: #f7f7f7;
+  color: #333;
+  cursor: pointer;
+  padding: 12px 15px;
+  margin: 0; /* Reset margin for h2 */
+  font-size: 1.1em;
+  font-weight: bold;
+  display: flex; /* To align title and icon */
+  justify-content: space-between; /* Puts icon to the far right */
+  align-items: center; /* Vertically aligns icon and text */
+  border-bottom: 1px solid #ddd; /* Separator line if items are hidden */
+}
+
+.acordeon-titulo:hover {
+  background-color: #e9e9e9;
+}
+
+.acordeon-titulo.open { /* Style when accordion is open */
+  border-bottom: 1px solid #ddd; /* Keep separator line when open */
+}
+
+.acordeon-icono {
+  font-size: 0.9em;
+  margin-left: 10px; /* Space between title text and icon */
+  transition: transform 0.2s ease-in-out; /* Smooth icon rotation if we use transform later */
+}
+
+.acordeon-items {
+  padding: 15px;
+  border-top: none; /* Top border is handled by title's bottom border */
+  background-color: #fff;
+  /* display: none; is set inline by JS initially */
+}
+
+/* Styling for items within the accordion if needed, e.g., appliance rows */
+.acordeon-items .form-group-energia {
+  /* Example: Adjust margin or padding if necessary for items within accordion */
+  margin-bottom: 8px;
+}
+
+.acordeon-items .form-group-energia:last-child {
+  margin-bottom: 0;
+}


### PR DESCRIPTION
This commit introduces two main enhancements to the 'Energía' section:

1.  **Accordion for Appliance Categories:**
    *   Appliance categories are now displayed in an accordion style.
    *   `calculador.js` was updated:
        *   `populateStandardApplianceList` and `populateDetailedApplianceList` now render HTML with specific classes for accordion structure (`acordeon-categoria-wrapper`, `acordeon-titulo`, `acordeon-icono`, `acordeon-items`).
        *   A new function `initAccordionEventListeners` was added to handle click events on category titles (`.acordeon-titulo`), toggling the visibility of associated items (`.acordeon-items`) and updating the expand/collapse icon ('▼'/'▲'). This function also adds/removes an 'open' class to the title for styling.
    *   `styles.css` was updated with new CSS rules to style the accordion components, including hover effects and an 'open' state for the title.

2.  **Rename Default Category:**
    *   In `backend/backend.py`, the `get_electrodomesticos_consumos` function was modified. Appliances without a specified category, which previously might have fallen into a 'Varios' category, are now grouped under "Artículos del Hogar".

These changes improve the organization and usability of the appliance list in the 'Energía' section. I confirmed correct functionality and appearance.