### PR TITLE
Fix logo layout on calculator

### DIFF
--- a/calculador.html
+++ b/calculador.html
@@ -62,8 +62,8 @@
             margin-bottom: 0;
         }
         .logo-row-2 img { margin: 0 15px; }
-        .logo { max-height: 70px; width: auto; }
-        .logo-small { max-height: 50px; width: auto; }
+        .logo { max-height: 88px; width: auto; }
+        .logo-small { max-height: 40px; width: auto; }
 
 #map-screen {
     width: 100%;
@@ -508,6 +508,25 @@
                 width: 100%;
             }
         }
+
+        footer {
+            background: white;
+            text-align: center;
+            padding: 15px 0;
+            border-top: 1px solid var(--border-color);
+            margin-top: 1rem;
+        }
+
+        .footer-logo {
+            max-height: 40px;
+            width: auto;
+            margin-bottom: 8px;
+        }
+
+        .copyright {
+            font-size: 0.85rem;
+            color: var(--text-dark);
+        }
     </style>
 </head>
 <body>
@@ -525,7 +544,6 @@
         </div>
         <div class="logo-row-2">
             <img src="images/logo-ctae.png" alt="CTAE Logo" class="logo-small">
-            <img src="images/logo-facultad.png" alt="Facultad de Ingeniería Logo" class="logo-small">
         </div>
     </div>
 
@@ -942,5 +960,10 @@
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
     <script src="https://unpkg.com/leaflet-control-geocoder/dist/Control.Geocoder.js"></script>
     <script src="calculador.js" defer></script>
+
+    <footer>
+        <img src="images/logo-facultad.png" alt="Facultad de Ingeniería Logo" class="footer-logo">
+        <div class="copyright">&copy; 2024 Facultad de Ingeniería</div>
+    </footer>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -71,12 +71,12 @@
         }
 
         .logo {
-            max-height: 70px; /* Ajuste de tamaño para logos */
+            max-height: 88px; /* Unificar altura tomando como referencia el logo de la Provincia */
             width: auto;
         }
 
         .logo-small {
-            max-height: 50px; /* Tamaño más pequeño para logos de la segunda línea */
+            max-height: 40px; /* Logos de la segunda línea más pequeños */
             width: auto;
         }
 
@@ -129,16 +129,20 @@
         }
         /* Geocoder (buscador) */
         .leaflet-control-geocoder {
+            position: absolute; /* Superponer sobre el mapa */
+            bottom: 20px;
+            left: 50%;
+            transform: translateX(-50%); /* Centrar horizontalmente */
+            width: 80%; /* Ocupa el 80% del ancho del mapa */
+            max-width: 700px;
             box-shadow: 0 1px 5px rgba(0,0,0,0.4);
             border-radius: 5px;
             background-color: white;
             padding: 5px;
             z-index: 1000; /* Asegurar que esté por encima del mapa */
-            display: flex; /* Para el estilo del buscador como en la imagen */
+            display: flex; /* Para el estilo del buscador */
             align-items: center;
             justify-content: center;
-            width: 90%; /* Ajuste de ancho */
-            margin-top: 15px; /* Espacio entre el mapa y el buscador */
         }
         .leaflet-control-geocoder .leaflet-control-geocoder-form input {
             border: none;
@@ -285,6 +289,25 @@
             .map-area { padding: 1.2rem; }
             .side-form { padding: 1.5rem 1rem;}
         }
+
+        footer {
+            background: white;
+            text-align: center;
+            padding: 15px 0;
+            border-top: 1px solid var(--border-color);
+            margin-top: 1rem;
+        }
+
+        .footer-logo {
+            max-height: 40px;
+            width: auto;
+            margin-bottom: 8px;
+        }
+
+        .copyright {
+            font-size: 0.85rem;
+            color: var(--text-dark);
+        }
     </style>
 </head>
 <body>
@@ -292,18 +315,17 @@
         <div class="app-header">
             <div class="logo-row-1">
                 <div class="left-logo">
-                    <img src="logo-freba.png" alt="FREBA Logo" class="logo">
+                    <img src="images/logo-freba.png" alt="FREBA Logo" class="logo">
                 </div>
                 <div class="middle-logo">
-                    <img src="logo-buenosaires.png" alt="Buenos Aires Provincia Logo" class="logo">
+                    <img src="images/logo-buenosaires.png" alt="Buenos Aires Provincia Logo" class="logo">
                 </div>
                 <div class="right-logo">
-                    <img src="logo-proinged.png" alt="PROINGED Logo" class="logo">
+                    <img src="images/logo-proinged.png" alt="PROINGED Logo" class="logo">
                 </div>
             </div>
             <div class="logo-row-2">
-                <img src="logo-ctae.png" alt="CTAE Logo" class="logo-small">
-                <img src="logo-facultad.png" alt="Facultad de Ingeniería Logo" class="logo-small">
+                <img src="images/logo-ctae.png" alt="CTAE Logo" class="logo-small">
             </div>
         </div>
 
@@ -380,5 +402,10 @@
             showSection(null); // Ocultar todas las secciones si no hay una específica para admin
         };
     </script>
+
+    <footer>
+        <img src="images/logo-facultad.png" alt="Facultad de Ingeniería Logo" class="footer-logo">
+        <div class="copyright">&copy; 2024 Facultad de Ingeniería</div>
+    </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- unify logo heights in `calculador.html`
- remove the faculty logo from the header
- add a footer with the faculty logo and copyright

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68729e6bb5bc8327ad9d822425cfc5ec