### PR TITLE
Geocode city lookup

### DIFF
--- a/backend/backend.py
+++ b/backend/backend.py
@@ -860,8 +860,19 @@ def buscar_ciudad():
         # Leer la hoja 'Ciudades', columnas A (código) y B (nombre)
         # Column A is index 0, Column B is index 1
         # Filas Excel 2 a 1990 -> iloc 1 a 1989
-        df_ciudades = pd.read_excel(EXCEL_FILE_PATH, sheet_name='Ciudades', usecols="A,B", header=None, skiprows=1, names=['codigo', 'ciudad_nombre'], engine='openpyxl')
-        print(f"DEBUG: Hoja 'Ciudades' leída. Total filas: {len(df_ciudades)}")
+        df_ciudades = pd.read_excel(
+            EXCEL_FILE_PATH,
+            sheet_name='Ciudades',
+            usecols="A,B",
+            header=None,
+            skiprows=1,
+            nrows=1989,  # Solo B2:B1990
+            names=['codigo', 'ciudad_nombre'],
+            engine='openpyxl'
+        )
+        print(
+            f"DEBUG: Hoja 'Ciudades' leída. Filas consideradas: {len(df_ciudades)}"
+        )
 
         ciudad_buscada_normalizada = normalizar_texto(ciudad_buscada)
 

--- a/calculador.js
+++ b/calculador.js
@@ -1788,6 +1788,17 @@ async function escribirPotenciaPanelEnExcel(potenciaPanel) {
 }
 
 
+// Utilidad para extraer la ciudad de una dirección con formato
+// "calle número, ciudad". Devuelve null si no se encuentra una coma.
+function extraerCiudadDeDireccion(direccion) {
+    if (!direccion) return null;
+    const partes = direccion.split(',');
+    if (partes.length >= 2) {
+        return partes[1].trim();
+    }
+    return null;
+}
+
 // --- Lógica del Mapa (EXISTENTE, CON PEQUEÑAS MEJORAS) ---
 
 function initMap() {
@@ -1837,35 +1848,30 @@ function initMap() {
             // if (longitudDisplay) longitudDisplay.value = userLocation.lng.toFixed(6); // Eliminado
             userSelections.location = userLocation;
 
-            let city = null;
+            let city = extraerCiudadDeDireccion(e.geocode.name);
             const addressProperties = e.geocode.properties && e.geocode.properties.address ? e.geocode.properties.address : {};
 
             console.log('Geocode e.geocode.name:', e.geocode.name); // Log para comparar
             console.log('Geocode properties.address:', addressProperties); // Log detallado de las propiedades
 
-            if (addressProperties.city) {
-                city = addressProperties.city;
-            } else if (addressProperties.town) {
-                city = addressProperties.town;
-            } else if (addressProperties.village) {
-                city = addressProperties.village;
-            } else if (addressProperties.hamlet) {
-                city = addressProperties.hamlet;
-            } else {
-                // Fallback si no se encuentran propiedades de ciudad en el geocoder.
-                // Se toma la parte posterior a la primera coma en e.geocode.name
-                if (e.geocode.name) {
+            if (!city) {
+                if (addressProperties.city) {
+                    city = addressProperties.city;
+                } else if (addressProperties.town) {
+                    city = addressProperties.town;
+                } else if (addressProperties.village) {
+                    city = addressProperties.village;
+                } else if (addressProperties.hamlet) {
+                    city = addressProperties.hamlet;
+                } else if (e.geocode.name) {
                     const parts = e.geocode.name.split(',');
                     if (parts.length > 1) {
                         city = parts[1].trim();
                     } else if (parts.length === 1) {
                         city = parts[0].trim();
                     }
-                    if (city) {
-                        console.log('Fallback: City extracted from e.geocode.name using comma:', city);
-                        if (city.toLowerCase().startsWith('partido de ')) {
-                            city = city.substring('partido de '.length).trim();
-                        }
+                    if (city && city.toLowerCase().startsWith('partido de ')) {
+                        city = city.substring('partido de '.length).trim();
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- read only the first 1989 city rows when searching
- add helper to extract city from address string
- prefer the comma-separated city in geocoder results before falling back to other fields

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872dbd9c33083278301ffe9e526066e