### PR TITLE
Remove step indicator and refine form styling

### DIFF
--- a/calculador.html
+++ b/calculador.html
@@ -180,20 +180,22 @@
         }
         .form-sections-container {
             flex: 1;
-            max-width: 320px;
+            max-width: 600px;
             min-width: 280px;
             background: white;
             padding: 2.2rem 2rem;
             border-radius: 10px;
             box-shadow: var(--shadow-subtle);
             box-sizing: border-box;
+            margin-left: auto;
+            margin-right: auto;
         }
         .form-section { margin-bottom: 2rem; }
         .form-section h2 {
             font-family: var(--font-heading);
-            font-size: 1.45rem;
+            font-size: 1.4rem;
             margin-top: 0;
-            color: var(--color-tertiary);
+            color: var(--text-grey-dark);
         }
         .selection-button {
             display: block;
@@ -292,6 +294,11 @@
             border-radius: 10px;
             box-shadow: var(--shadow-subtle);
             margin-bottom: 2rem;
+            width: 100%;
+            max-width: 600px;
+            box-sizing: border-box;
+            margin-left: auto;
+            margin-right: auto;
         }
         .data-form-screen .form-group select {
             border: 1px solid var(--border-color);
@@ -527,6 +534,34 @@
             font-size: 0.85rem;
             color: var(--text-dark);
         }
+
+        /* Estilos unificados para títulos de formularios */
+        .main-content h1 {
+            font-family: var(--font-heading);
+            font-size: 1.8rem;
+            color: var(--color-tertiary);
+            margin-top: 0;
+            margin-bottom: 1rem;
+            text-align: left;
+        }
+
+        .form-section h2,
+        .form-sections-container .form-section h2 {
+            font-family: var(--font-heading);
+            font-size: 1.4rem;
+            color: var(--text-grey-dark);
+            margin-top: 0;
+            margin-bottom: 0.8rem;
+            text-align: left;
+        }
+
+        .selection-summary {
+            font-family: var(--font-body);
+            font-size: 1rem;
+            color: var(--color-secondary);
+            text-align: center;
+            margin-bottom: 0.5rem;
+        }
     </style>
 </head>
 <body>
@@ -613,7 +648,7 @@
                 </div>
             </div>
             <div class="main-content">
-                <div class="step-indicator" id="step-indicator-text">Paso 1 > <strong>Datos Meteorológicos</strong></div>
+                <div id="selection-summary" class="selection-summary"></div>
                 <div id="data-meteorologicos-section">
                     <h1>¿En qué zona se encuentra la intalación?</h1>
                     <div class="form-group">

--- a/calculador.js
+++ b/calculador.js
@@ -2150,6 +2150,20 @@ function updateStepIndicator(currentSectionId) {
         console.warn(`[updateStepIndicator] Section ID '${currentSectionId}' not found in sectionInfoMap.`);
         currentStepText = `${userTypeDisplay}: Paso Desconocido`;
     }
+
+    const summaryEl = document.getElementById('selection-summary');
+    if (summaryEl) {
+        const typeText = userSelections.userType
+            ? `Usuario ${userSelections.userType === 'experto' ? 'Experto' : 'Básico'}`
+            : '';
+        const instText = userSelections.installationType || '';
+        const incomeText = userSelections.incomeLevel
+            ? `Nivel de Ingreso ${userSelections.incomeLevel}`
+            : '';
+        summaryEl.textContent = [typeText, instText, incomeText]
+            .filter(Boolean)
+            .join('. ');
+    }
     stepIndicatorText.textContent = currentStepText;
 }
 
@@ -2893,6 +2907,27 @@ function setupNavigationButtons() {
     }
 }
 
+function setupSidebarNavigation() {
+    const navMap = {
+        'sidebar-datos': 'data-meteorologicos-section',
+        'sidebar-energia': 'energia-section',
+        'sidebar-paneles': 'paneles-section',
+        'sidebar-inversor': 'inversor-section',
+        'sidebar-perdidas': 'perdidas-section',
+        'sidebar-analisis-economico': 'analisis-economico-section',
+        'sidebar-resultados': 'resultados-informe'
+    };
+    Object.entries(navMap).forEach(([sidebarId, target]) => {
+        const element = document.getElementById(sidebarId);
+        if (element) {
+            element.addEventListener('click', () => {
+                showScreen(target);
+                updateStepIndicator(target);
+            });
+        }
+    });
+}
+
 
 // --- INIT principal (Se ejecuta al cargar el DOM) (EXISTENTE, MODIFICADO) ---
 document.addEventListener('DOMContentLoaded', async () => {
@@ -2904,6 +2939,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                                                 // Usamos 'await' para asegurar que los electrodomésticos estén cargados
                                                 // antes de que se muestre la pantalla, si es la de energía.
     setupNavigationButtons(); // 5. Configura todos los botones de navegación y otros listeners.
+    setupSidebarNavigation();
 
     // 6. Muestra la pantalla guardada o la inicial después de que todo esté cargado y listo
     const currentScreenId = 'map-screen';

--- a/index.html
+++ b/index.html
@@ -236,12 +236,16 @@
             flex-direction: column;
             justify-content: flex-start;
             min-width: 320px;
+            max-width: 600px;
+            box-sizing: border-box;
+            margin-left: auto;
+            margin-right: auto;
         }
         .side-form h2 {
             font-family: var(--font-heading);
-            font-size: 1.45rem;
+            font-size: 1.4rem;
             margin-top: 0;
-            color: var(--color-tertiary);
+            color: var(--text-grey-dark);
         }
         .form-section {
             margin-bottom: 2rem;
@@ -308,6 +312,34 @@
             font-size: 0.85rem;
             color: var(--text-dark);
         }
+
+        /* Estilos unificados para títulos de formularios */
+        .main-content h1 {
+            font-family: var(--font-heading);
+            font-size: 1.8rem;
+            color: var(--color-tertiary);
+            margin-top: 0;
+            margin-bottom: 1rem;
+            text-align: left;
+        }
+
+        .form-section h2,
+        .side-form h2 {
+            font-family: var(--font-heading);
+            font-size: 1.4rem;
+            color: var(--text-grey-dark);
+            margin-top: 0;
+            margin-bottom: 0.8rem;
+            text-align: left;
+        }
+
+        .selection-summary {
+            font-family: var(--font-body);
+            font-size: 1rem;
+            color: var(--color-secondary);
+            text-align: center;
+            margin-bottom: 0.5rem;
+        }
     </style>
 </head>
 <body>
@@ -331,15 +363,16 @@
 
         <div class="content-area">
             <div class="map-area">
-                <div id="map"></div>
-                <div id="geocoder-container" class="leaflet-control-geocoder">
-                    </div>
-                <div class="location-info">
-                    <b>Latitud:</b> <span id="latitud-display"></span> &nbsp;
-                    <b>Longitud:</b> <span id="longitud-display"></span>
+            <div id="map"></div>
+            <div id="geocoder-container" class="leaflet-control-geocoder">
                 </div>
+            <div class="location-info">
+                <b>Latitud:</b> <span id="latitud-display"></span> &nbsp;
+                <b>Longitud:</b> <span id="longitud-display"></span>
             </div>
+        </div>
             <div class="side-form">
+                <div id="selection-summary" class="selection-summary"></div>
                 <div class="form-section" id="supply-section" style="display:none;">
                     <h2>Tipo de instalación</h2>
                     <button class="selection-button" id="residential-button">Residencial</button>

--- a/prueba.html
+++ b/prueba.html
@@ -84,10 +84,38 @@
     button[type="submit"]:hover {
       background: var(--color-primary);
     }
+
+    /* Estilos unificados para títulos de formularios */
+    h1 {
+      font-family: var(--font-heading);
+      font-size: 1.8rem;
+      color: var(--color-tertiary);
+      margin-top: 0;
+      margin-bottom: 1rem;
+      text-align: left;
+    }
+
+    .form-group h2 {
+      font-family: var(--font-heading);
+      font-size: 1.4rem;
+      color: var(--text-grey-dark);
+      margin-top: 0;
+      margin-bottom: 0.8rem;
+      text-align: left;
+    }
+
+    .selection-summary {
+      font-family: var(--font-body);
+      font-size: 1rem;
+      color: var(--color-secondary);
+      text-align: center;
+      margin-bottom: 0.5rem;
+    }
   </style>
 </head>
 <body>
   <h1>Ingreso de Datos</h1>
+  <div id="selection-summary" class="selection-summary"></div>
   <form id="data-form">
     <!-- Tipo de usuario -->
     <div class="form-group">


### PR DESCRIPTION
## Summary
- drop textual step indicator from wizard
- style step titles left-aligned in blue
- style form titles smaller in dark grey
- enforce consistent width for form containers

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68758947ca948327a1b605409d7431a5