### PR TITLE
Implement basic commercial monthly consumption flow

### DIFF
--- a/calculador.js
+++ b/calculador.js
@@ -1505,6 +1505,14 @@ function initElectrodomesticosSection() {
         });
 
     } else { // Basic user
+        if (userSelections.installationType === 'Comercial' || userSelections.installationType === 'PYME') {
+            console.log('[DEBUG] Basic Comercial/PYME: redirecting to factura consumption form.');
+            userSelections.metodoIngresoConsumoEnergia = 'boletaMensual';
+            saveUserSelections();
+            showScreen('consumo-factura-section');
+            updateStepIndicator('consumo-factura-section');
+            return;
+        }
         modoSeleccionContainer.style.display = 'none';
         if (summaryContainer) summaryContainer.style.display = 'flex';
         populateStandardApplianceList(listContainer);


### PR DESCRIPTION
## Summary
- show monthly bill input when a basic user selects Commercial or PYME installation

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687648695b648327a2bbfc96d32b02b7