### PR TITLE
feat: Set fixed height for form container

### DIFF
--- a/calculador.html
+++ b/calculador.html
@@ -229,6 +229,7 @@
             border-radius: 10px;
             box-shadow: var(--shadow-subtle);
             overflow: hidden;
+            height: 680px;
         }
         .data-form-screen .sidebar {
             width: 250px;
@@ -274,7 +275,7 @@
         .data-form-screen .main-content {
             flex-grow: 1;
             padding: 2.5rem;
-            min-height: 480px; /* Unificar tamaño de las pantallas de formularios */
+            overflow-y: auto;
         }
         .data-form-screen .main-content h1 {
             font-family: var(--font-heading);


### PR DESCRIPTION
This commit adjusts the CSS for the main form container (`.data-form-screen`) to have a fixed height. This prevents the container from changing size when you navigate between steps with different amounts of content, providing a more stable and visually consistent user experience.

The main content area will now scroll vertically if its content exceeds the container's height.