### PR TITLE
Fix(JS): Remove legacy API call conflicting with dynamic model lookup

### DIFF
--- a/calculador.js
+++ b/calculador.js
@@ -1228,32 +1228,17 @@ async function initMarcaPanelOptions() {
     }
 }
 
-async function initModeloPanelOptions() {
+function initModeloPanelOptions() {
     const inputElement = document.getElementById('modelo-panel-input');
     if (!inputElement) {
         console.error("Input 'modelo-panel-input' no encontrado.");
         return;
     }
-    inputElement.value = 'Cargando...'; // Indicate loading state
-    try {
-        const resp = await fetch('http://127.0.0.1:5000/api/get_modelo_panel');
-        if (!resp.ok) {
-            throw new Error(`HTTP ${resp.status}`);
-        }
-        const data = await resp.json();
-        const valor = data.valor ?? '';
-        inputElement.value = valor;
-
-        // Also update the value in our state object
-        if(userSelections.panelesSolares) {
-            userSelections.panelesSolares.modelo = valor;
-            saveUserSelections();
-        }
-
-    } catch (error) {
-        console.error('Error al cargar el modelo de panel desde Excel:', error);
-        inputElement.value = 'Error al cargar modelo';
-    }
+    // This function should only prepare the field.
+    // The actual model is now populated by updatePanelModel().
+    // We set it to the saved value, or empty if there's no saved value.
+    const savedModel = userSelections.panelesSolares?.modelo;
+    inputElement.value = savedModel || ''; // Show saved model or clear it
 }
 
 function initModeloTemperaturaPanelOptions() {


### PR DESCRIPTION
This commit resolves a bug where the 'Modelo de Panel' field was not being populated correctly.

The root cause was a legacy `fetch` call within the `initModeloPanelOptions` function. This function was making a `GET` request to an old endpoint (`/api/get_modelo_panel`) every time the panel model sub-form was displayed, interfering with and overriding the new dynamic lookup logic implemented in the `updatePanelModel` function.

The fix removes the incorrect `fetch` call from `initModeloPanelOptions`. This function's responsibility is now limited to preparing the input field. The `updatePanelModel` function is now solely responsible for fetching and populating the model name, ensuring the feature works as intended.