### PR TITLE
Fix(JS): Remove calls to deleted function `escribirDatoEnExcel`

### DIFF
--- a/calculador.js
+++ b/calculador.js
@@ -449,11 +449,9 @@ async function initSuperficieSection() {
                 const valorFloat = parseFloat(valor);
                 userSelections.superficieRodea.valor = valorFloat;
                 userSelections.superficieRodea.descripcion = descripcion;
-                escribirDatoEnExcel(descripcion, 'N6');
             } else {
                 userSelections.superficieRodea.valor = null;
                 userSelections.superficieRodea.descripcion = null;
-                escribirDatoEnExcel(null, 'N6'); // Opcional: enviar null para limpiar la celda
             }
             saveUserSelections();
             console.log('[initSuperficieSection] Superficie rodea seleccionada (select):', userSelections.superficieRodea);
@@ -546,11 +544,9 @@ async function initRugosidadSection() {
             if (valor && valor !== '') {
                 userSelections.rugosidadSuperficie.valor = parseFloat(valor);
                 userSelections.rugosidadSuperficie.descripcion = descripcion;
-                escribirDatoEnExcel(descripcion, 'N7');
             } else {
                 userSelections.rugosidadSuperficie.valor = null;
                 userSelections.rugosidadSuperficie.descripcion = null;
-                escribirDatoEnExcel(null, 'N7'); // Opcional: enviar null para limpiar la celda
             }
             saveUserSelections();
             console.log('[initRugosidadSection] Rugosidad de superficie seleccionada (select):', userSelections.rugosidadSuperficie);


### PR DESCRIPTION
This commit removes several calls to the legacy function `escribirDatoEnExcel` which had been deleted in a previous refactoring.

These leftover calls were causing a `ReferenceError` in the browser console and preventing subsequent JavaScript from executing correctly. The calls have been removed from the event listeners in `initSuperficieSection` and `initRugosidadSection`.

This change, combined with the existing fix for the `/api/get_panel_model` endpoint, should resolve the issues you were experiencing.