### PR TITLE
Fix(HTML): Add missing container for inverter options

### DIFF
--- a/calculador.html
+++ b/calculador.html
@@ -929,8 +929,10 @@
                     </div>
                 </div>
                 <div id="inversor-section" style="display:none;">
-                    <h1>De las opciones disponibles,seleccione el modelo de inversor que desea instalar</h1>
-                    <p style="text-align: center; font-style: italic; padding: 20px;">La selección detallada del modelo de inversor se habilitará en futuras versiones.</p>
+                    <h1>De las opciones disponibles, seleccione el modelo de inversor que desea instalar</h1>
+                    <div id="inversor-options-container" class="form-group">
+                        <!-- El menú desplegable de inversores se insertará aquí dinámicamente -->
+                    </div>
                     <div class="form-actions">
                         <button type="button" id="back-to-paneles" class="back-button">Atrás</button>
                         <button type="submit" id="next-to-perdidas">Siguiente</button>


### PR DESCRIPTION
I've added the missing `<div id="inversor-options-container"></div>` to the `inversor-section` in `calculador.html`.

The JavaScript function `initInversorSection` was unable to find this container, which prevented the dynamic inverter selection dropdown from being created and displayed to you.

This change ensures that the container exists, allowing the JavaScript to correctly inject the inverter options into the form.