### PR TITLE
feat: Add expert user report and conditional display

### DIFF
--- a/calculador.js
+++ b/calculador.js
@@ -2751,6 +2751,10 @@ function setupNavigationButtons() {
                 }
                 const informeFinal = await response.json();
                 console.log('Informe recibido del backend:', informeFinal);
+
+                // Add userType to the report data before saving
+                informeFinal.userType = userSelections.userType;
+
                 localStorage.setItem('informeSolar', JSON.stringify(informeFinal));
                 window.location.href = 'informe.html';
             } catch (error) {

--- a/explore_excel.py
+++ b/explore_excel.py
@@ -1,18 +1,18 @@
 import pandas as pd
 
-def explore_sheet_raw(file_path, sheet_name):
+def explore_sheets(file_path):
     try:
-        print(f"\n--- Raw exploration of sheet: {sheet_name} ---")
-        # Read the sheet with no header
-        df = pd.read_excel(file_path, sheet_name=sheet_name, header=None)
-        # Print the first 20 rows so I can see the structure
-        print(df.head(20))
+        print("\n--- Exploring Paneles comerciales ---")
+        df_paneles = pd.read_excel(file_path, sheet_name='Paneles comerciales')
+        print(df_paneles.columns)
+
+        print("\n--- Exploring Inversores genéricos ---")
+        df_inversores = pd.read_excel(file_path, sheet_name='Inversores genéricos')
+        print(df_inversores.columns)
 
     except Exception as e:
-        print(f"An error occurred while reading {sheet_name}: {e}")
+        print(f"An error occurred: {e}")
 
 if __name__ == "__main__":
     excel_file = 'backend/Calculador Solar - web 06-24_con ayuda - modificaciones 2025_5.xlsx'
-
-    # Let's inspect 'base de datos (3)' raw
-    explore_sheet_raw(excel_file, 'base de datos (3)')
+    explore_sheets(excel_file)

--- a/informe.html
+++ b/informe.html
@@ -120,98 +120,181 @@
 </head>
 <body>
   <div class="solar-report">
-    <div class="report-title">
-      Datos técnicos del dimensionamiento
+    <div class="report-title" id="report-main-title">
+      <!-- Title will be set by JS -->
     </div>
 
-    <div class="report-section">
-      <div class="section-header">• Consumo y generación</div>
-      <table class="report-table">
-        <tr>
-          <td>Consumo anual de energía eléctrica</td>
-          <td><span id="consumo_anual_kwh"></span> (kWh/año)</td>
-        </tr>
-        <tr>
-          <td>Generación anual de energía eléctrica</td>
-          <td><span id="energia_generada_anual"></span> (kWh/año)</td>
-        </tr>
-        <tr>
-          <td>Energía para autoconsumo</td>
-          <td><span id="autoconsumo"></span> (kWh/año)</td>
-        </tr>
-        <tr>
-          <td>Energía inyectada a la red</td>
-          <td><span id="inyectada_red"></span> (kWh/año)</td>
-        </tr>
-      </table>
-    </div>
-
-    <div class="report-section">
-      <div class="section-header">• Detalles de la instalación</div>
-      <table class="report-table">
-        <tr>
-          <td>Potencia de paneles sugerida</td>
-          <td><span id="potencia_panel_sugerida"></span> W</td>
-        </tr>
-        <tr>
-          <td>Cantidad paneles necesarios</td>
-          <td><span id="numero_paneles"></span></td>
-        </tr>
-        <tr>
-          <td>Superficie necesaria</td>
-          <td><span id="area_paneles_m2"></span> m2</td>
-        </tr>
-      </table>
-    </div>
-
-    <div class="report-section">
-        <table class="report-table">
+    <!-- Basic User Report Sections -->
+    <div id="basic-report-sections">
+        <div class="report-section">
+          <div class="section-header">• Consumo y generación</div>
+          <table class="report-table">
             <tr>
-                <td>Vida útil del proyecto (años)</td>
-                <td><span id="vida_util"></span></td>
+              <td>Consumo anual de energía eléctrica</td>
+              <td><span id="basico_consumo_anual_kwh"></span> (kWh/año)</td>
             </tr>
-        </table>
+            <tr>
+              <td>Generación anual de energía eléctrica</td>
+              <td><span id="basico_energia_generada_anual"></span> (kWh/año)</td>
+            </tr>
+            <tr>
+              <td>Energía para autoconsumo</td>
+              <td><span id="basico_autoconsumo"></span> (kWh/año)</td>
+            </tr>
+            <tr>
+              <td>Energía inyectada a la red</td>
+              <td><span id="basico_inyectada_red"></span> (kWh/año)</td>
+            </tr>
+          </table>
+        </div>
+        <div class="report-section">
+          <div class="section-header">• Detalles de la instalación</div>
+          <table class="report-table">
+            <tr>
+              <td>Potencia de paneles sugerida</td>
+              <td><span id="basico_potencia_panel_sugerida"></span> W</td>
+            </tr>
+            <tr>
+              <td>Cantidad paneles necesarios</td>
+              <td><span id="basico_numero_paneles"></span></td>
+            </tr>
+            <tr>
+              <td>Superficie necesaria</td>
+              <td><span id="basico_area_paneles_m2"></span> m2</td>
+            </tr>
+          </table>
+        </div>
+        <div class="report-section">
+            <table class="report-table">
+                <tr>
+                    <td>Vida útil del proyecto (años)</td>
+                    <td><span id="basico_vida_util"></span></td>
+                </tr>
+            </table>
+        </div>
+        <div class="report-section">
+          <div class="section-header">Resultados económicos</div>
+          <div class="section-header" style="font-size: 1.1rem; background: none; color: #333;">"• Lo que gastas actualmente en energía eléctrica en un año (no contempla impuestos)"</div>
+          <table class="report-table">
+            <tr>
+              <td>Costo actual anual en Energía Eléctrica (sin instalación fotovoltaica)</td>
+              <td><span id="basico_moneda_1"></span> <span id="basico_costo_actual"></span></td>
+            </tr>
+          </table>
+          <div class="section-header" style="font-size: 1.1rem; background: none; color: #333;">• Costos e ingresos relacionados a la instalación fotovoltaica</div>
+          <table class="report-table">
+            <tr>
+              <td>Inversión inicial a realizar en año cero</td>
+              <td><span id="basico_moneda_2"></span> <span id="basico_inversion_inicial"></span></td>
+            </tr>
+            <tr>
+              <td>Costo de mantenimiento anual</td>
+              <td><span id="basico_moneda_3"></span> <span id="basico_mantenimiento"></span></td>
+            </tr>
+            <tr>
+              <td>Costo futuro de energía eléctrica consumida de la red</td>
+              <td><span id="basico_moneda_4"></span> <span id="basico_costo_futuro"></span></td>
+            </tr>
+            <tr>
+              <td>Ingreso anual por inyección de energía a la red</td>
+              <td><span id="basico_moneda_5"></span> <span id="basico_ingreso_red"></span></td>
+            </tr>
+          </table>
+        </div>
+        <div class="report-section">
+          <div class="section-header">• Contribución a la mitigación del cambio climático</div>
+          <table class="report-table">
+            <tr>
+              <td>Emisiones de gases de efecto invernadero evitadas con la instalación</td>
+              <td><span id="basico_emisiones"></span> tCO2</td>
+            </tr>
+          </table>
+        </div>
     </div>
 
-    <div class="report-section">
-      <div class="section-header">Resultados económicos</div>
-      <div class="section-header" style="font-size: 1.1rem; background: none; color: #333;">"• Lo que gastas actualmente en energía eléctrica en un año (no contempla impuestos)"</div>
-      <table class="report-table">
-        <tr>
-          <td>Costo actual anual en Energía Eléctrica (sin instalación fotovoltaica)</td>
-          <td><span id="moneda-display-1"></span> <span id="costo_actual"></span></td>
-        </tr>
-      </table>
-
-      <div class="section-header" style="font-size: 1.1rem; background: none; color: #333;">• Costos e ingresos relacionados a la instalación fotovoltaica</div>
-      <table class="report-table">
-        <tr>
-          <td>Inversión inicial a realizar en año cero</td>
-          <td><span id="moneda-display-2"></span> <span id="inversion_inicial"></span></td>
-        </tr>
-        <tr>
-          <td>Costo de mantenimiento anual</td>
-          <td><span id="moneda-display-3"></span> <span id="mantenimiento"></span></td>
-        </tr>
-        <tr>
-          <td>Costo futuro de energía eléctrica consumida de la red</td>
-          <td><span id="moneda-display-4"></span> <span id="costo_futuro"></span></td>
-        </tr>
-        <tr>
-          <td>Ingreso anual por inyección de energía a la red</td>
-          <td><span id="moneda-display-5"></span> <span id="ingreso_red"></span></td>
-        </tr>
-      </table>
-    </div>
-
-    <div class="report-section">
-      <div class="section-header">• Contribución a la mitigación del cambio climático</div>
-      <table class="report-table">
-        <tr>
-          <td>Emisiones de gases de efecto invernadero evitadas con la instalación</td>
-          <td><span id="emisiones"></span> tCO2</td>
-        </tr>
-      </table>
+    <!-- Expert User Report Sections -->
+    <div id="expert-report-sections" style="display: none;">
+        <!-- Radiación -->
+        <div class="report-section">
+            <div class="section-header">• Radiación:</div>
+            <table class="report-table">
+                <tr>
+                    <td>Radiación Anual Incidente:</td>
+                    <td><span id="experto_radiacion_anual"></span> kWh/m2/año</td>
+                </tr>
+                <tr>
+                    <td>Incremento respecto de un plano horizontal</td>
+                    <td><span id="experto_incremento_radiacion"></span> %</td>
+                </tr>
+            </table>
+        </div>
+        <!-- Consumo (similar to basic) -->
+        <div class="report-section">
+            <div class="section-header">• Consumo:</div>
+            <table class="report-table">
+                <tr>
+                    <td>Consumo anual de energía eléctrica</td>
+                    <td><span id="experto_consumo_anual"></span> (kWh/año)</td>
+                </tr>
+            </table>
+        </div>
+        <!-- Panel/es -->
+        <div class="report-section">
+            <div class="section-header">• Panel/es:</div>
+            <table class="report-table">
+                <tr><td>Marca</td><td><span id="experto_panel_marca"></span></td></tr>
+                <tr><td>Potencia</td><td><span id="experto_panel_potencia"></span> W</td></tr>
+                <tr><td>Modelo</td><td><span id="experto_panel_modelo"></span></td></tr>
+                <tr><td>Eficiencia informada por el fabricante del panel</td><td><span id="experto_panel_eficiencia"></span> %</td></tr>
+                <tr><td>Cantidad Paneles Necesarios</td><td><span id="experto_cantidad_paneles"></span></td></tr>
+                <tr><td>Superficie necesaria</td><td><span id="experto_superficie"></span> m2</td></tr>
+                <tr><td>Potencia Instalada W</td><td><span id="experto_potencia_instalada"></span> W</td></tr>
+            </table>
+        </div>
+        <!-- Inversor/es -->
+        <div class="report-section">
+            <div class="section-header">• Inversor/es:</div>
+            <table class="report-table">
+                <tr><td>Inversores sugeridos</td><td><span id="experto_inversor_sugerido"></span></td></tr>
+                <tr><td>Potencia</td><td><span id="experto_inversor_potencia"></span> W</td></tr>
+                <tr><td>Eficiencia informada por el fabricante del INV.</td><td><span id="experto_inversor_eficiencia"></span> %</td></tr>
+                <tr><td>Cantidad de Inversores</td><td><span id="experto_cantidad_inversores"></span></td></tr>
+            </table>
+        </div>
+        <!-- Datos económicos del proyecto -->
+        <div class="report-section">
+            <div class="section-header">Datos económicos del proyecto:</div>
+            <div class="section-header" style="font-size: 1.1rem; background: none; color: #333;">• Resultado económico sin realizar la instalación fotovoltaica</div>
+            <table class="report-table">
+                <tr><td>CARGO VARIABLE POR ENERGÍA DEMANDADA EN PICO</td><td><span id="experto_moneda_1"></span> <span id="experto_cargo_pico"></span></td></tr>
+                <tr><td>CARGO VARIABLE POR ENERGÍA DEMANDADA FUERA DE PICO</td><td><span id="experto_moneda_2"></span> <span id="experto_cargo_fuera_pico"></span></td></tr>
+                <tr><td>Costo actual anual en Energía Eléctrica (sin instalación fotovoltaica)</td><td><span id="experto_moneda_3"></span> <span id="experto_costo_actual"></span></td></tr>
+                <tr><td>Costo total actualizado del consumo Energía Eléctrica</td><td><span id="experto_moneda_4"></span> <span id="experto_costo_total_actualizado"></span></td></tr>
+            </table>
+            <div class="section-header" style="font-size: 1.1rem; background: none; color: #333;">• Resultado económico realizando la instalación fotovoltaica</div>
+            <table class="report-table">
+                <tr><td>Inversión inicial:</td><td><span id="experto_moneda_5"></span> <span id="experto_inversion_inicial"></span></td></tr>
+                <tr><td>Costo de mantenimiento por año:</td><td><span id="experto_moneda_6"></span> <span id="experto_mantenimiento"></span></td></tr>
+                <tr><td>Tarifa inyección de Energía Eléctrica:</td><td><span id="experto_moneda_7"></span> <span id="experto_tarifa_inyeccion"></span></td></tr>
+                <tr><td>Costo futuro de energía eléctrica consumida de la red</td><td><span id="experto_moneda_8"></span> <span id="experto_costo_futuro"></span></td></tr>
+                <tr><td>Ahorro total actualizado en energía eléctrica consumida</td><td><span id="experto_moneda_9"></span> <span id="experto_ahorro_actualizado"></span></td></tr>
+                <tr><td>Ingreso anual por inyección de energía a la red</td><td><span id="experto_moneda_10"></span> <span id="experto_ingreso_anual_inyeccion"></span></td></tr>
+                <tr><td>Ingreso total por inyección de energía a la red actualizado</td><td><span id="experto_moneda_11"></span> <span id="experto_ingreso_total_inyeccion"></span></td></tr>
+            </table>
+            <div class="section-header" style="font-size: 1.1rem; background: none; color: #333;">Resultado económico actualizado del proyecto</div>
+            <table class="report-table">
+                <tr><td>Ahorro neto logrado durante la vida util del proyecto</td><td><span id="experto_moneda_12"></span> <span id="experto_ahorro_neto"></span></td></tr>
+            </table>
+        </div>
+        <!-- Emisiones -->
+        <div class="report-section">
+          <div class="section-header">• Contribución a la mitigación del cambio climático</div>
+          <table class="report-table">
+            <tr><td>Emisiones de Gases de Efecto Invernadero evitadas</td><td></td></tr>
+            <tr><td>Primer Año</td><td><span id="experto_emisiones_primer_ano"></span> Toneladas CO2</td></tr>
+            <tr><td>Totales</td><td><span id="experto_emisiones_totales"></span> Toneladas CO2</td></tr>
+          </table>
+        </div>
     </div>
 
     <div class="informe-btns">

--- a/informe.js
+++ b/informe.js
@@ -46,39 +46,86 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
-    // Poblar los datos del informe en el HTML
+    // --- Conditional Display Logic ---
+    const userType = datos.userType || 'basico'; // Default to basic if not specified
+    const basicReport = document.getElementById('basic-report-sections');
+    const expertReport = document.getElementById('expert-report-sections');
+    const reportTitle = document.getElementById('report-main-title');
 
-    // • Consumo y generación
-    setTextContent('consumo_anual_kwh', datos.consumo_anual_kwh?.toFixed(0) || 'N/A');
-    setTextContent('energia_generada_anual', datos.energia_generada_anual?.toFixed(0) || 'N/A');
-    setTextContent('autoconsumo', datos.autoconsumo?.toFixed(0) || 'N/A');
-    setTextContent('inyectada_red', datos.inyectada_red?.toFixed(0) || 'N/A');
+    if (userType === 'experto') {
+        basicReport.style.display = 'none';
+        expertReport.style.display = 'block';
+        reportTitle.textContent = 'Resultado del dimensionamiento fotovoltaico (Detallado)';
+    } else {
+        basicReport.style.display = 'block';
+        expertReport.style.display = 'none';
+        reportTitle.textContent = 'Datos técnicos del dimensionamiento';
+    }
 
-    // • Detalles de la instalación
-    setTextContent('potencia_panel_sugerida', datos.panel_seleccionado?.['Pmax[W]'] || 'N/A');
-    setTextContent('numero_paneles', datos.numero_paneles || 'N/A');
-    setTextContent('area_paneles_m2', datos.area_paneles_m2?.toFixed(2) || 'N/A');
-
-    // Vida útil
-    setTextContent('vida_util', datos.vida_util || '25');
-
-    // Resultados económicos
+    // --- Data Population ---
+    const formatNumber = (num, decimals = 0) => num?.toLocaleString('es-AR', { minimumFractionDigits: decimals, maximumFractionDigits: decimals }) || 'N/A';
     const monedaSimbolo = datos.moneda === 'Dólares' ? 'U$D' : '$';
-    const currencyElements = document.querySelectorAll('[id^="moneda-display"]');
-    currencyElements.forEach(el => {
-        el.textContent = monedaSimbolo;
-    });
 
-    const formatNumber = (num) => num?.toLocaleString('es-AR', { maximumFractionDigits: 0 }) || 'N/A';
-
-    setTextContent('costo_actual', formatNumber(datos.costo_actual));
-    setTextContent('inversion_inicial', formatNumber(datos.inversion_inicial));
-    setTextContent('mantenimiento', formatNumber(datos.mantenimiento));
-    setTextContent('costo_futuro', formatNumber(datos.costo_futuro));
-    setTextContent('ingreso_red', formatNumber(datos.ingreso_red));
-
-    // • Contribución a la mitigación del cambio climático
-    setTextContent('emisiones', datos.emisiones?.toFixed(1) || 'N/A');
+    if (userType === 'experto') {
+        // Populate Expert Report
+        // Radiación
+        setTextContent('experto_radiacion_anual', 'N/A'); // Placeholder
+        setTextContent('experto_incremento_radiacion', 'N/A'); // Placeholder
+        // Consumo
+        setTextContent('experto_consumo_anual', formatNumber(datos.consumo_anual_kwh, 0));
+        // Panel
+        setTextContent('experto_panel_marca', datos.panel_seleccionado?.Marca || 'N/A');
+        setTextContent('experto_panel_potencia', datos.panel_seleccionado?.['Pmax[W]'] || 'N/A');
+        setTextContent('experto_panel_modelo', datos.panel_seleccionado?.Modelo || 'N/A');
+        setTextContent('experto_panel_eficiencia', datos.panel_seleccionado?.['Eficiencia[%]'] || 'N/A');
+        setTextContent('experto_cantidad_paneles', datos.numero_paneles || 'N/A');
+        setTextContent('experto_superficie', formatNumber(datos.area_paneles_m2, 2));
+        setTextContent('experto_potencia_instalada', (datos.potencia_sistema_kwp * 1000)?.toFixed(0) || 'N/A');
+        // Inversor
+        setTextContent('experto_inversor_sugerido', datos.tipo_inversor || 'N/A');
+        setTextContent('experto_inversor_potencia', (datos.potencia_inversor_kwa * 1000)?.toFixed(0) || 'N/A');
+        setTextContent('experto_inversor_eficiencia', 'N/A'); // Placeholder
+        setTextContent('experto_cantidad_inversores', '1'); // Placeholder
+        // Emisiones
+        setTextContent('experto_emisiones_primer_ano', formatNumber(datos.emisiones, 1));
+        setTextContent('experto_emisiones_totales', 'N/A'); // Placeholder
+        // Económico
+        document.querySelectorAll('[id^="experto_moneda_"]').forEach(el => el.textContent = monedaSimbolo);
+        setTextContent('experto_cargo_pico', 'N/A'); // Placeholder
+        setTextContent('experto_cargo_fuera_pico', 'N/A'); // Placeholder
+        setTextContent('experto_costo_actual', formatNumber(datos.costo_actual));
+        setTextContent('experto_costo_total_actualizado', 'N/A'); // Placeholder
+        setTextContent('experto_inversion_inicial', formatNumber(datos.inversion_inicial));
+        setTextContent('experto_mantenimiento', formatNumber(datos.mantenimiento));
+        setTextContent('experto_tarifa_inyeccion', 'N/A'); // Placeholder
+        setTextContent('experto_costo_futuro', formatNumber(datos.costo_futuro));
+        setTextContent('experto_ahorro_actualizado', 'N/A'); // Placeholder
+        setTextContent('experto_ingreso_anual_inyeccion', formatNumber(datos.ingreso_red));
+        setTextContent('experto_ingreso_total_inyeccion', 'N/A'); // Placeholder
+        setTextContent('experto_ahorro_neto', 'N/A'); // Placeholder
+    } else {
+        // Populate Basic Report
+        // Consumo y generación
+        setTextContent('basico_consumo_anual', formatNumber(datos.consumo_anual_kwh, 0));
+        setTextContent('basico_generacion_anual', formatNumber(datos.energia_generada_anual, 0));
+        setTextContent('basico_autoconsumo', formatNumber(datos.autoconsumo, 0));
+        setTextContent('basico_inyectada_red', formatNumber(datos.inyectada_red, 0));
+        // Detalles de la instalación
+        setTextContent('basico_potencia_panel', datos.panel_seleccionado?.['Pmax[W]'] || 'N/A');
+        setTextContent('basico_cantidad_paneles', datos.numero_paneles || 'N/A');
+        setTextContent('basico_superficie', formatNumber(datos.area_paneles_m2, 2));
+        // Vida útil
+        setTextContent('basico_vida_util', datos.vida_util || '25');
+        // Resultados económicos
+        document.querySelectorAll('[id^="basico_moneda_"]').forEach(el => el.textContent = monedaSimbolo);
+        setTextContent('basico_costo_actual', formatNumber(datos.costo_actual));
+        setTextContent('basico_inversion_inicial', formatNumber(datos.inversion_inicial));
+        setTextContent('basico_mantenimiento', formatNumber(datos.mantenimiento));
+        setTextContent('basico_costo_futuro', formatNumber(datos.costo_futuro));
+        setTextContent('basico_ingreso_red', formatNumber(datos.ingreso_red));
+        // Contribución
+        setTextContent('basico_emisiones', formatNumber(datos.emisiones, 1));
+    }
 
 
     // Descargar PDF con html2pdf.js


### PR DESCRIPTION
- Implements the HTML structure for the detailed Expert User Report in `informe.html`, based on the user-provided layout.
- Wraps the Basic and Expert report sections in separate containers for conditional rendering.
- Updates `calculador.js` to save the `userType` to localStorage when generating the report.
- Updates `informe.js` to read the `userType` and display the correct report (Basic or Expert).
- Adds data population logic for the new Expert report fields, using placeholders for data not yet calculated by the backend.