### PR TITLE
Use environment-based API URL in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "description": "\"# controlador-solar\"",
   "main": "index.js",
   "scripts": {
-    "test": "jest"
+    "test": "export API_URL=http://127.0.0.1:5000/ && jest"
   },
   "repository": {
     "type": "git",

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -16,7 +16,8 @@ afterAll(() => {
 });
 
 test('GET / should return HTML page', async () => {
-  const res = await axios.get('http://127.0.0.1:5000/');
+  const apiUrl = process.env.API_URL || 'http://127.0.0.1:5000/';
+  const res = await axios.get(apiUrl);
   expect(res.status).toBe(200);
   expect(res.data).toContain('<!DOCTYPE html>');
 });


### PR DESCRIPTION
## Summary
- Replace hard-coded API URL in tests with `process.env.API_URL`
- Set `API_URL` in the test script before running Jest

## Testing
- `npm test` *(fails: AxiosError: Request failed with status code 500)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d46f869483278d9d4565b9dc1cc4