### PR TITLE
refactor: use global API url

### DIFF
--- a/calculador.html
+++ b/calculador.html
@@ -991,6 +991,7 @@
 
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
     <script src="https://unpkg.com/leaflet-control-geocoder/dist/Control.Geocoder.js"></script>
+    <script>window.API_URL = 'http://tu-backend:5000';</script>
     <script src="calculador.js" defer></script>
 
     <footer>

--- a/calculador.js
+++ b/calculador.js
@@ -1,6 +1,6 @@
 console.log('🤖 calculador.js cargado - flujo de controlador ajustado y persistencia de datos');
 
-const API_URL = import.meta.env.VITE_API_URL;
+const API_URL = window.API_URL;
 
 let map, marker;
 let userLocation = { lat: -34.6037, lng: -58.3816 }; // Buenos Aires por defecto


### PR DESCRIPTION
## Summary
- switch calculador.js to read API URL from `window.API_URL`
- define `window.API_URL` in HTML before loading calculador.js

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a64701367c8327b125d9d1b2ed73f7