### PR TITLE
Fix(calculador): Correct API URL to enable map functionality

### DIFF
--- a/calculador.js
+++ b/calculador.js
@@ -1,6 +1,6 @@
 console.log('🤖 calculador.js cargado - flujo de controlador ajustado y persistencia de datos');
 
-const API_URL = import.meta.env.VITE_API_URL;
+const API_URL = 'http://localhost:8000';
 
 let map, marker;
 let userLocation = { lat: -34.6037, lng: -58.3816 }; // Buenos Aires por defecto


### PR DESCRIPTION
The `calculador.js` file was using a Vite-specific environment variable (`import.meta.env.VITE_API_URL`) which is not available when running `calculador.html` directly or on a simple static server. This resulted in failed API calls, preventing the map and other interactive elements from loading.

This change hardcodes the API URL to `http://localhost:8000`, which is the address the backend server listens on according to the Dockerfile configuration. This allows the frontend to correctly communicate with the backend in a deployed environment.