### PR TITLE
feat: Update header and footer logos

### DIFF
--- a/calculador.html
+++ b/calculador.html
@@ -580,7 +580,7 @@
     <div class="app-header">
         <div class="logo-row-1">
             <div class="left-logo">
-                <img src="images/logo-freba.png" alt="FREBA Logo" class="logo">
+                    <img src="images/logo-freba.png" alt="FREBA Logo" class="logo-small">
             </div>
             <div class="middle-logo">
                 <img src="images/logo-buenosaires.png" alt="Buenos Aires Provincia Logo" class="logo">
@@ -588,9 +588,6 @@
             <div class="right-logo">
                 <img src="images/logo-proinged.png" alt="PROINGED Logo" class="logo">
             </div>
-        </div>
-        <div class="logo-row-2">
-            <img src="images/logo-ctae.png" alt="CTAE Logo" class="logo-small">
         </div>
     </div>
 
@@ -995,11 +992,8 @@
 
     <footer>
         <div class="footer-logos">
-            <img src="images/logo-facultad.png" alt="Facultad de Ingeniería Logo" class="footer-logo">
-            <img src="images/logo-freba.png" alt="FREBA Logo" class="footer-logo">
-            <img src="images/logo-buenosaires.png" alt="Buenos Aires Provincia Logo" class="footer-logo">
-            <img src="images/logo-proinged-full.png" alt="PROINGED Logo" class="footer-logo">
             <img src="images/logo-ctae.png" alt="CTAE Logo" class="footer-logo">
+            <img src="images/logo-facultad.png" alt="Facultad de Ingeniería Logo" class="footer-logo">
         </div>
         <div class="copyright">&copy; 2024 Facultad de Ingeniería</div>
     </footer>


### PR DESCRIPTION
- In the header, the Febra logo is now smaller, and the logos are in a single row.
- The footer now only contains the CTAE and FIO logos.

Note: The `api.test.js` test is failing, but this appears to be a pre-existing issue with the backend tests and is unrelated to the frontend HTML changes in this commit.