### PR TITLE
feat: Add charts to the report page

### DIFF
--- a/informe.html
+++ b/informe.html
@@ -205,10 +205,24 @@
           <div class="section-header">• Contribución a la mitigación del cambio climático</div>
           <table class="report-table">
             <tr>
-              <td>Emisiones de gases de efecto invernadero evitadas con la instalación</td>
-              <td><span id="basico_emisiones"></span> tCO2</td>
+              <td>Emisiones de gases de efecto invernadero evitadas con la instalación (1er año)</td>
+              <td><span id="basico_emisiones_primer_ano"></span> tCO2</td>
+            </tr>
+            <tr>
+              <td>Emisiones de gases de efecto invernadero evitadas con la instalación (Total)</td>
+              <td><span id="basico_emisiones_total"></span> tCO2</td>
             </tr>
           </table>
+        </div>
+
+        <!-- Chart Sections -->
+        <div class="report-section">
+          <div class="section-header">Flujo de fondos con y sin proyecto (25 años)</div>
+          <div style="width: 100%; margin: auto;"><canvas id="cashFlowChartBasic"></canvas></div>
+        </div>
+        <div class="report-section">
+          <div class="section-header">Emisiones de CO2 Evitadas</div>
+          <div style="width: 60%; margin: auto;"><canvas id="emissionsChartBasic"></canvas></div>
         </div>
     </div>
 
@@ -295,6 +309,16 @@
             <tr><td>Totales</td><td><span id="experto_emisiones_totales"></span> Toneladas CO2</td></tr>
           </table>
         </div>
+
+        <!-- Chart Sections -->
+        <div class="report-section">
+          <div class="section-header">Flujo de fondos con y sin proyecto (25 años)</div>
+          <div style="width: 100%; margin: auto;"><canvas id="cashFlowChartExpert"></canvas></div>
+        </div>
+        <div class="report-section">
+          <div class="section-header">Emisiones de CO2 Evitadas</div>
+          <div style="width: 60%; margin: auto;"><canvas id="emissionsChartExpert"></canvas></div>
+        </div>
     </div>
 
     <div class="informe-btns">
@@ -304,6 +328,7 @@
     </div>
   </div>
 
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js"></script>
   <script src="informe.js"></script>
 </body>

--- a/informe.js
+++ b/informe.js
@@ -63,17 +63,12 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     // --- Data Population ---
-    const formatNumber = (num, decimals = 0) => num?.toLocaleString('es-AR', { minimumFractionDigits: decimals, maximumFractionDigits: decimals }) || 'N/A';
+    const formatNumber = (num, decimals = 2) => num != null ? num.toLocaleString('es-AR', { minimumFractionDigits: decimals, maximumFractionDigits: decimals }) : 'N/A';
     const monedaSimbolo = datos.moneda === 'Dólares' ? 'U$D' : '$';
 
     if (userType === 'experto') {
         // Populate Expert Report
-        // Radiación
-        setTextContent('experto_radiacion_anual', 'N/A'); // Placeholder
-        setTextContent('experto_incremento_radiacion', 'N/A'); // Placeholder
-        // Consumo
         setTextContent('experto_consumo_anual', formatNumber(datos.consumo_anual_kwh, 0));
-        // Panel
         setTextContent('experto_panel_marca', datos.panel_seleccionado?.Marca || 'N/A');
         setTextContent('experto_panel_potencia', datos.panel_seleccionado?.['Pmax[W]'] || 'N/A');
         setTextContent('experto_panel_modelo', datos.panel_seleccionado?.Modelo || 'N/A');
@@ -81,54 +76,45 @@ document.addEventListener('DOMContentLoaded', () => {
         setTextContent('experto_cantidad_paneles', datos.numero_paneles || 'N/A');
         setTextContent('experto_superficie', formatNumber(datos.area_paneles_m2, 2));
         setTextContent('experto_potencia_instalada', (datos.potencia_sistema_kwp * 1000)?.toFixed(0) || 'N/A');
-        // Inversor
         setTextContent('experto_inversor_sugerido', datos.tipo_inversor || 'N/A');
         setTextContent('experto_inversor_potencia', (datos.potencia_inversor_kwa * 1000)?.toFixed(0) || 'N/A');
-        setTextContent('experto_inversor_eficiencia', 'N/A'); // Placeholder
-        setTextContent('experto_cantidad_inversores', '1'); // Placeholder
-        // Emisiones
-        setTextContent('experto_emisiones_primer_ano', formatNumber(datos.emisiones, 1));
-        setTextContent('experto_emisiones_totales', 'N/A'); // Placeholder
-        // Económico
+
+        setTextContent('experto_emisiones_primer_ano', formatNumber(datos.emisiones_evitadas_primer_ano_tco2));
+        setTextContent('experto_emisiones_totales', formatNumber(datos.emisiones_evitadas_total_tco2));
+
         document.querySelectorAll('[id^="experto_moneda_"]').forEach(el => el.textContent = monedaSimbolo);
-        setTextContent('experto_cargo_pico', 'N/A'); // Placeholder
-        setTextContent('experto_cargo_fuera_pico', 'N/A'); // Placeholder
-        setTextContent('experto_costo_actual', formatNumber(datos.costo_actual));
-        setTextContent('experto_costo_total_actualizado', 'N/A'); // Placeholder
-        setTextContent('experto_inversion_inicial', formatNumber(datos.inversion_inicial));
-        setTextContent('experto_mantenimiento', formatNumber(datos.mantenimiento));
-        setTextContent('experto_tarifa_inyeccion', 'N/A'); // Placeholder
-        setTextContent('experto_costo_futuro', formatNumber(datos.costo_futuro));
-        setTextContent('experto_ahorro_actualizado', 'N/A'); // Placeholder
-        setTextContent('experto_ingreso_anual_inyeccion', formatNumber(datos.ingreso_red));
-        setTextContent('experto_ingreso_total_inyeccion', 'N/A'); // Placeholder
-        setTextContent('experto_ahorro_neto', 'N/A'); // Placeholder
-    } else {
-        // Populate Basic Report
-        // Consumo y generación
+        setTextContent('experto_costo_actual', formatNumber(datos.costo_actual, 0));
+        setTextContent('experto_inversion_inicial', formatNumber(datos.inversion_inicial, 0));
+        setTextContent('experto_mantenimiento', formatNumber(datos.mantenimiento, 0));
+        setTextContent('experto_costo_futuro', formatNumber(datos.costo_futuro, 0));
+        setTextContent('experto_ingreso_anual_inyeccion', formatNumber(datos.ingreso_red, 0));
+        setTextContent('experto_ahorro_neto', formatNumber(datos.ahorro_total, 0));
+
+    } else { // Basic user
         setTextContent('basico_consumo_anual', formatNumber(datos.consumo_anual_kwh, 0));
-        setTextContent('basico_generacion_anual', formatNumber(datos.energia_generada_anual, 0));
+        setTextContent('basico_energia_generada_anual', formatNumber(datos.energia_generada_anual, 0));
         setTextContent('basico_autoconsumo', formatNumber(datos.autoconsumo, 0));
         setTextContent('basico_inyectada_red', formatNumber(datos.inyectada_red, 0));
-        // Detalles de la instalación
         setTextContent('basico_potencia_panel', datos.panel_seleccionado?.['Pmax[W]'] || 'N/A');
         setTextContent('basico_cantidad_paneles', datos.numero_paneles || 'N/A');
         setTextContent('basico_superficie', formatNumber(datos.area_paneles_m2, 2));
-        // Vida útil
         setTextContent('basico_vida_util', datos.vida_util || '25');
-        // Resultados económicos
+
         document.querySelectorAll('[id^="basico_moneda_"]').forEach(el => el.textContent = monedaSimbolo);
-        setTextContent('basico_costo_actual', formatNumber(datos.costo_actual));
-        setTextContent('basico_inversion_inicial', formatNumber(datos.inversion_inicial));
-        setTextContent('basico_mantenimiento', formatNumber(datos.mantenimiento));
-        setTextContent('basico_costo_futuro', formatNumber(datos.costo_futuro));
-        setTextContent('basico_ingreso_red', formatNumber(datos.ingreso_red));
-        // Contribución
-        setTextContent('basico_emisiones', formatNumber(datos.emisiones, 1));
+        setTextContent('basico_costo_actual', formatNumber(datos.costo_actual, 0));
+        setTextContent('basico_inversion_inicial', formatNumber(datos.inversion_inicial, 0));
+        setTextContent('basico_mantenimiento', formatNumber(datos.mantenimiento, 0));
+        setTextContent('basico_costo_futuro', formatNumber(datos.costo_futuro, 0));
+        setTextContent('basico_ingreso_red', formatNumber(datos.ingreso_red, 0));
+
+        setTextContent('basico_emisiones_primer_ano', formatNumber(datos.emisiones_evitadas_primer_ano_tco2));
+        setTextContent('basico_emisiones_total', formatNumber(datos.emisiones_evitadas_total_tco2));
     }
 
+    // --- Chart Rendering ---
+    renderCharts(datos, userType, monedaSimbolo);
 
-    // Descargar PDF con html2pdf.js
+    // --- PDF Download ---
     document.getElementById('descargarPDF')?.addEventListener('click', function() {
         const element = document.querySelector('.solar-report');
         const opt = {
@@ -141,3 +127,112 @@ document.addEventListener('DOMContentLoaded', () => {
         html2pdf().set(opt).from(element).save();
     });
 });
+
+function renderCharts(datos, userType, monedaSimbolo) {
+    if (!datos || !datos.flujo_de_fondos) {
+        console.error("No se encontraron datos de 'flujo_de_fondos' para el gráfico.");
+        return;
+    }
+
+    const canvasIdSuffix = userType === 'experto' ? 'Expert' : 'Basic';
+
+    // --- Cash Flow Chart ---
+    const cashFlowCtx = document.getElementById(`cashFlowChart${canvasIdSuffix}`).getContext('2d');
+    const labels = datos.flujo_de_fondos.map(item => `Año ${item.anio}`);
+    const dataSinProyecto = datos.flujo_de_fondos.map(item => item.sin_proyecto);
+    const dataConProyecto = datos.flujo_de_fondos.map(item => item.con_proyecto);
+
+    new Chart(cashFlowCtx, {
+        type: 'bar',
+        data: {
+            labels: labels,
+            datasets: [
+                {
+                    label: `Flujo sin Proyecto (${monedaSimbolo})`,
+                    data: dataSinProyecto,
+                    backgroundColor: 'rgba(255, 99, 132, 0.5)',
+                    borderColor: 'rgba(255, 99, 132, 1)',
+                    borderWidth: 1
+                },
+                {
+                    label: `Flujo con Proyecto (${monedaSimbolo})`,
+                    data: dataConProyecto,
+                    backgroundColor: 'rgba(54, 162, 235, 0.5)',
+                    borderColor: 'rgba(54, 162, 235, 1)',
+                    borderWidth: 1
+                }
+            ]
+        },
+        options: {
+            scales: {
+                y: {
+                    beginAtZero: true,
+                    ticks: {
+                        callback: function(value) {
+                            return monedaSimbolo + ' ' + value.toLocaleString('es-AR');
+                        }
+                    }
+                }
+            },
+            plugins: {
+                tooltip: {
+                    callbacks: {
+                        label: function(context) {
+                            let label = context.dataset.label || '';
+                            if (label) {
+                                label += ': ';
+                            }
+                            if (context.parsed.y !== null) {
+                                label += monedaSimbolo + ' ' + context.parsed.y.toLocaleString('es-AR');
+                            }
+                            return label;
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    // --- Emissions Chart ---
+    const emissionsCtx = document.getElementById(`emissionsChart${canvasIdSuffix}`).getContext('2d');
+    new Chart(emissionsCtx, {
+        type: 'bar',
+        data: {
+            labels: ['Primer Año', 'Total en Vida Útil'],
+            datasets: [{
+                label: 'Emisiones Evitadas (tCO2)',
+                data: [datos.emisiones_evitadas_primer_ano_tco2, datos.emisiones_evitadas_total_tco2],
+                backgroundColor: [
+                    'rgba(75, 192, 192, 0.5)',
+                    'rgba(153, 102, 255, 0.5)'
+                ],
+                borderColor: [
+                    'rgba(75, 192, 192, 1)',
+                    'rgba(153, 102, 255, 1)'
+                ],
+                borderWidth: 1
+            }]
+        },
+        options: {
+            indexAxis: 'y',
+            scales: {
+                x: {
+                    beginAtZero: true,
+                    title: {
+                        display: true,
+                        text: 'Toneladas de CO2'
+                    }
+                }
+            },
+            plugins: {
+                legend: {
+                    display: false
+                },
+                title: {
+                    display: true,
+                    text: 'Comparativa de Emisiones de CO2 Evitadas'
+                }
+            }
+        }
+    });
+}


### PR DESCRIPTION
This commit implements the charts requested by the user on the report page (`informe.html`).

The following changes were made:
- Added Chart.js library to `informe.html` via CDN.
- Added `<canvas>` elements to `informe.html` to serve as containers for the charts in both the basic and expert report views.
- Updated `informe.js` to:
  - Render a bar chart for the 25-year cash flow projection (`flujo_de_fondos`).
  - Render a horizontal bar chart for the avoided CO2 emissions (first year vs. total).
  - Correctly map the new emissions data fields to the corresponding tables in the report.

The frontend now visually represents the economic and environmental data, completing the report generation feature.