### PR TITLE
feat: Add help text for basic user in appliance form

### DIFF
--- a/calculador.js
+++ b/calculador.js
@@ -1697,6 +1697,25 @@ function initElectrodomesticosSection() {
 
     } else { // Basic Residencial
         console.log('[DEBUG] Basic Residencial: showing appliance list.');
+
+        // START: Add help text for basic residential user
+        const helpTextId = 'basic-residential-help-text';
+        const existingHelpText = document.getElementById(helpTextId);
+        if (existingHelpText) {
+            existingHelpText.remove();
+        }
+
+        const helpText = document.createElement('p');
+        helpText.id = helpTextId;
+        helpText.className = 'form-description';
+        helpText.textContent = 'Ingresa la cantidad de electrodomésticos de cada tipo que tenés en tu casa.';
+
+        // Insert the help text before the appliance list container
+        if (listContainer) {
+            listContainer.before(helpText);
+        }
+        // END: Add help text
+
         listContainer.style.display = 'block'; // Show appliance list container
         if (summaryContainer) summaryContainer.style.display = 'flex'; // Show summary
         populateStandardApplianceList(listContainer); // Populate it with appliances


### PR DESCRIPTION
This commit adds a new help text to the appliance form specifically for the 'básico' user profile.

- Modified `initElectrodomesticosSection` in `calculador.js` to dynamically create and inject a `<p>` tag with the help text "Ingresa la cantidad de electrodomésticos de cada tipo que tenés en tu casa."
- The help text is only displayed for basic users in the residential flow.
- Added logic to prevent duplicate help text elements from being created if the section is re-initialized.