### PR TITLE
fix: Remove incorrect help text for expert user

### DIFF
--- a/calculador.html
+++ b/calculador.html
@@ -844,7 +844,6 @@
                         <h2>¿Cómo desea ingresar los datos de consumo?</h2>
                         <p class="form-description">
                             Tres opciones para ingresar tu consumo de energía eléctrica:<br>
-                            - Ingresar que electrodomésticos tenés en tu casa (tipo y cantidad), y el sistema estimará las horas de uso estándar.<br>
                             - Ingresar que electrodomésticos tenés en tu casa: tipo, cantidad y horas de uso al mes, distinguiendo entre verano e invierno.<br>
                             - Ingresa el consumo mensual registrado en tu factura “de luz” en los últimos 12 meses.
                         </p>


### PR DESCRIPTION
This commit removes a line of help text from the energy form's expert user flow that was incorrect. The text "- Ingresar que electrodomésticos tenés en tu casa (tipo y cantidad), y el sistema estimará las horas de uso estándar." was a duplicate of another option and has been removed from `calculador.html`.