### PR TITLE
fix: Skip income level step for expert commercial/PYME users

### DIFF
--- a/calculador.js
+++ b/calculador.js
@@ -2239,8 +2239,9 @@ function setupNavigationButtons() {
             userSelections.installationType = 'Comercial';
             saveUserSelections();
             if (userSelections.userType === 'experto') {
-                showMapScreenFormSection('income-section');
-                updateStepIndicator('income-section');
+                showScreen('data-form-screen');
+                if (dataMeteorologicosSection) dataMeteorologicosSection.style.display = 'block';
+                updateStepIndicator('data-meteorologicos-section');
             } else {
                 showMapScreenFormSection('income-section');
                 updateStepIndicator('income-section');
@@ -2253,8 +2254,9 @@ function setupNavigationButtons() {
             userSelections.installationType = 'PYME';
             saveUserSelections();
             if (userSelections.userType === 'experto') {
-                showMapScreenFormSection('income-section');
-                updateStepIndicator('income-section');
+                showScreen('data-form-screen');
+                if (dataMeteorologicosSection) dataMeteorologicosSection.style.display = 'block';
+                updateStepIndicator('data-meteorologicos-section');
             } else {
                 showMapScreenFormSection('income-section');
                 updateStepIndicator('income-section');


### PR DESCRIPTION
This commit modifies the navigation flow in `calculador.js` for expert users.

- When an expert user selects 'Comercial' or 'PYME' as their installation type, they will now be taken directly to the 'data-meteorologicos-section', skipping the 'income-section'.
- The 'income-section' will now only be shown to basic users or expert users who select 'Residencial'.
- This aligns the application flow with the requirement that income level is not relevant for non-residential expert calculations.