### PR TITLE
This commit fixes a bug where the 'expert' user type was not being co…

### DIFF
--- a/calculador.js
+++ b/calculador.js
@@ -2852,8 +2852,8 @@ function setupNavigationButtons() {
                 const informeFinal = await response.json();
                 console.log('Informe recibido del backend:', informeFinal);
 
-                // Add userType to the report data before saving
-                informeFinal.userType = userSelections.userType;
+                // The userType from the backend's response is now the source of truth.
+                // The redundant and buggy overwriting of the value has been removed.
 
                 localStorage.setItem('informeSolar', JSON.stringify(informeFinal));
                 window.location.href = 'informe.html';


### PR DESCRIPTION
…rrectly preserved, causing the basic report to be displayed instead of the expert report.

The root cause was a redundant line in `calculador.js` that overwrote the `userType` from the backend's JSON response with a potentially stale value from the frontend's state. This line has been removed.

The application now correctly relies on the `userType` provided by the backend as the single source of truth for rendering the report, making the process more robust and ensuring the correct report is displayed for the selected user type.