### PR TITLE
Feature: Skip income form for non-residential basic users

### DIFF
--- a/calculador.js
+++ b/calculador.js
@@ -2008,9 +2008,10 @@ function setupNavigationButtons() {
                 showScreen('data-form-screen');
                 if (dataMeteorologicosSection) dataMeteorologicosSection.style.display = 'block';
                 updateStepIndicator('data-meteorologicos-section');
-            } else {
-                showMapScreenFormSection('income-section');
-                updateStepIndicator('income-section');
+            } else { // Basic user, non-residential
+                showScreen('data-form-screen');
+                if (dataMeteorologicosSection) dataMeteorologicosSection.style.display = 'block';
+                updateStepIndicator('data-meteorologicos-section');
             }
         });
     }
@@ -2023,9 +2024,10 @@ function setupNavigationButtons() {
                 showScreen('data-form-screen');
                 if (dataMeteorologicosSection) dataMeteorologicosSection.style.display = 'block';
                 updateStepIndicator('data-meteorologicos-section');
-            } else {
-                showMapScreenFormSection('income-section');
-                updateStepIndicator('income-section');
+            } else { // Basic user, non-residential
+                showScreen('data-form-screen');
+                if (dataMeteorologicosSection) dataMeteorologicosSection.style.display = 'block';
+                updateStepIndicator('data-meteorologicos-section');
             }
         });
     }


### PR DESCRIPTION
This change modifies the navigation flow in the calculator form (`calculador.js`).

When a 'Usuario Básico' (Basic User) selects 'Comercial' or 'PYME' as their customer type, they will now be taken directly to the main data input form, skipping the 'Nivel de Ingreso' (Income Level) section.

This aligns the user flow with the requirement that the income level is not needed for non-residential basic users.