### PR TITLE
Feature: Add help text to income level section

### DIFF
--- a/calculador.html
+++ b/calculador.html
@@ -645,6 +645,12 @@
                 </div>
                 <div class="form-section" id="income-section" style="display:none;">
                     <h2>Nivel de ingreso</h2>
+                    <div class="form-description" style="text-align: left; margin-top: 1rem; font-size: 0.9rem; line-height: 1.5;">
+                        <b>Aplicación de subsidios</b><br>
+                        De acuerdo a su nivel de ingresos se determina la tarifa de energía eléctrica correspondiente.<br>
+                        Si desconoce en que nivel de ingresos se encuentra, por favor, consulte la siguiente web para más información:<br>
+                        <a href="https://www.argentina.gob.ar/subsidios" target="_blank" rel="noopener noreferrer">https://www.argentina.gob.ar/subsidios</a>
+                    </div>
                     <button class="selection-button" id="income-high-button">ALTO</button>
                     <button class="selection-button" id="income-medium-button">MEDIO</button>
                     <button class="selection-button" id="income-low-button">BAJO</button>


### PR DESCRIPTION
This change adds a descriptive help text to the 'Nivel de Ingreso' (Income Level) section of the calculator form (`calculador.html`).

The new text informs the user about the application of subsidies based on their income level and provides a link to the official government website for more information. This is displayed for residential users as requested.