### PR TITLE
Style: Reduce font size for appliance category titles

### DIFF
--- a/calculador.html
+++ b/calculador.html
@@ -431,6 +431,7 @@
 
         #electrodomesticos-list h2 { /* Category headers */
             font-family: var(--font-heading, 'Bebas Neue', sans-serif);
+            font-size: 1.2rem; /* Reduced font size for category titles */
             color: var(--color-tertiary, #5884D6);
             margin-top: 1rem;
             margin-bottom: 0.75rem;


### PR DESCRIPTION
This change modifies the CSS in `calculador.html` to reduce the font size of the `h2` elements that serve as category titles in the appliance list.

This improves the layout and visibility of the form, especially on smaller screens, as requested by the user.