### PR TITLE
feat: Add conditional title to economic results

### DIFF
--- a/backend/engine.py
+++ b/backend/engine.py
@@ -82,6 +82,9 @@ def run_calculation_engine(user_data, excel_path):
         costo_maint_total_anual = to_numeric_safe(df_datos_entrada.iloc[198, 2])
         tarifa_consumo_usd = to_numeric_safe(df_datos_entrada.iloc[210, 4])
 
+        # New value for conditional title logic
+        saldo_anual_favor = to_numeric_safe(df_area_trabajo.iloc[32, 5]) # F33
+
         print(f"DEBUG Economics: inversion={costo_inv_total}, mantenimiento={costo_maint_total_anual}, tarifa={tarifa_consumo_usd}")
 
         inversion_inicial = costo_inv_total
@@ -108,6 +111,7 @@ def run_calculation_engine(user_data, excel_path):
             "costo_anual_reducido": costo_futuro_anual,
             "gasto_anual_sin_fv": gasto_anual_sin_fv,
             "inversion_inicial": inversion_inicial,
+            "saldo_anual_favor": saldo_anual_favor,
         }
         chart_data = { # Using simulated data for now
             "monthly_consumption": [gasto_anual_sin_fv/12] * 12, # More realistic simulation

--- a/informe.html
+++ b/informe.html
@@ -227,7 +227,7 @@
             <div class="section-header">Resultados económicos</div>
 
             <div class="economic-result-box blue-box">
-                <div class="economic-result-label">Si realiza la instalación fotovoltaica su costo anual en energía eléctrica se reducirá a</div>
+                <div class="economic-result-label" id="basico_resultado_label">Si realiza la instalación fotovoltaica su costo anual en energía eléctrica se reducirá a</div>
                 <div class="economic-result-value">
                     <span id="basico_costo_reducido"></span>
                     <span class="currency">U$S</span>

--- a/informe.js
+++ b/informe.js
@@ -127,6 +127,17 @@ document.addEventListener('DOMContentLoaded', () => {
         setTextContent('basico_costo_sin_instalacion', formatNumber(economicData.gasto_anual_sin_fv, 0));
         setTextContent('basico_inversion_inicial_total', formatNumber(economicData.inversion_inicial, 0));
 
+        // Conditional title based on saldo_anual_favor
+        const saldoAnualFavor = economicData.saldo_anual_favor || 0;
+        const resultadoLabel = document.getElementById('basico_resultado_label');
+        if (resultadoLabel) {
+            if (saldoAnualFavor > 0) {
+                resultadoLabel.textContent = 'Si realiza la instalación fotovoltaica tendrá un saldo neto anual a su favor de';
+            } else {
+                resultadoLabel.textContent = 'Si realiza la instalación fotovoltaica su costo anual en energía eléctrica se reducirá a';
+            }
+        }
+
         // Emissions
         setTextContent('basico_emisiones_total_vida_util', formatNumber(datos.emisiones_evitadas_total_tco2, 2));
     }


### PR DESCRIPTION
This commit implements a conditional title in the basic user report's economic results section. The title changes based on the value of a cell read from the project's Excel file, as requested by the user.

Changes include:
- Added an ID to the relevant HTML element in `informe.html`.
- Updated `backend/engine.py` to read the conditional value from the Excel sheet.
- Implemented the conditional logic in `informe.js` to set the title's text.