### PR TITLE
fix: Display correct value for conditional economic result

### DIFF
--- a/backend/engine.py
+++ b/backend/engine.py
@@ -83,8 +83,11 @@ def run_calculation_engine(user_data, excel_path):
         costo_maint_total_anual = to_numeric_safe(df_datos_entrada.iloc[198, 2])
         tarifa_consumo_usd = to_numeric_safe(df_datos_entrada.iloc[210, 4])
 
-        # New value for conditional title logic
-        saldo_anual_favor = to_numeric_safe(df_resultados.iloc[32, 5]) # F33
+        # New value for conditional title logic (F33 = C39 - C38 - C36)
+        c39 = to_numeric_safe(df_resultados.iloc[38, 2])
+        c38 = to_numeric_safe(df_resultados.iloc[37, 2])
+        c36 = to_numeric_safe(df_resultados.iloc[35, 2])
+        saldo_anual_favor = c39 - c38 - c36
 
         print(f"DEBUG Economics: inversion={costo_inv_total}, mantenimiento={costo_maint_total_anual}, tarifa={tarifa_consumo_usd}")
 

--- a/informe.js
+++ b/informe.js
@@ -123,7 +123,6 @@ document.addEventListener('DOMContentLoaded', () => {
         document.querySelectorAll('#basic-report-sections .currency').forEach(el => {
             el.textContent = monedaSimbolo;
         });
-        setTextContent('basico_costo_reducido', formatNumber(economicData.costo_anual_reducido, 0));
         setTextContent('basico_costo_sin_instalacion', formatNumber(economicData.gasto_anual_sin_fv, 0));
         setTextContent('basico_inversion_inicial_total', formatNumber(economicData.inversion_inicial, 0));
 
@@ -133,9 +132,13 @@ document.addEventListener('DOMContentLoaded', () => {
         if (resultadoLabel) {
             if (saldoAnualFavor > 0) {
                 resultadoLabel.textContent = 'Si realiza la instalación fotovoltaica tendrá un saldo neto anual a su favor de';
+                setTextContent('basico_costo_reducido', formatNumber(saldoAnualFavor, 0));
             } else {
                 resultadoLabel.textContent = 'Si realiza la instalación fotovoltaica su costo anual en energía eléctrica se reducirá a';
+                setTextContent('basico_costo_reducido', formatNumber(economicData.costo_anual_reducido, 0));
             }
+        } else {
+            setTextContent('basico_costo_reducido', formatNumber(economicData.costo_anual_reducido, 0));
         }
 
         // Emissions


### PR DESCRIPTION
This commit fixes an issue where the incorrect value was displayed next to the conditional title in the economic results section.

The JavaScript logic in `informe.js` has been updated to:
- Display the `saldo_anual_favor` value when there is a net profit.
- Display the `costo_anual_reducido` value when there is a net cost.

This ensures the displayed value is always consistent with the contextual title.