### PR TITLE
feat: Simplify energy consumption form for basic users

### DIFF
--- a/calculador.html
+++ b/calculador.html
@@ -883,6 +883,15 @@
                         </div>
                     </div>
                     <!-- Nueva sección para Consumo por Factura (AHORA ANIDADA) -->
+                    <div id="consumo-promedio-section" style="display:none; margin-top: 1.5rem;">
+                        <hr>
+                        <h3>Ingreso de Consumo Mensual Según Boleta de Energía Eléctrica (Boleta de luz)</h3>
+                        <div class="form-group">
+                            <label for="consumo-promedio-mes">Energía promedio consumida por mes (kWh/mes):</label>
+                            <input type="number" min="0" id="consumo-promedio-mes" name="consumo-promedio-mes" class="form-control">
+                        </div>
+                    </div>
+
                     <div id="consumo-factura-section" style="display:none; margin-top: 1.5rem;">
                         <hr>
                         <h3>Ingrese su Consumo Mensual según Factura (kWh)</h3>

--- a/calculador.js
+++ b/calculador.js
@@ -1451,13 +1451,12 @@ function initElectrodomesticosSection() {
 
 
         if (userSelections.installationType === 'Comercial' || userSelections.installationType === 'PYME') {
-        console.log('[DEBUG] Basic Comercial/PYME: showing factura consumption form within energia-section.');
-            userSelections.metodoIngresoConsumoEnergia = 'boletaMensual';
+        console.log('[DEBUG] Basic Comercial/PYME: showing average consumption form.');
+        userSelections.metodoIngresoConsumoEnergia = 'promedioMensual'; // New method
 
-
-        if (consumoFacturaSection) consumoFacturaSection.style.display = 'block'; // Show the monthly bill form
-        if (summaryContainer) summaryContainer.style.display = 'flex'; // Show the summary box
-        // listContainer is already hidden by default state above
+        const consumoPromedioSection = document.getElementById('consumo-promedio-section');
+        if(consumoPromedioSection) consumoPromedioSection.style.display = 'block';
+        if (summaryContainer) summaryContainer.style.display = 'flex';
 
     } else { // Basic Residencial
         console.log('[DEBUG] Basic Residencial: showing appliance list.');
@@ -2360,8 +2359,14 @@ function setupNavigationButtons() {
     const nextToPanelesButton = document.getElementById('next-to-paneles');
     if (nextToPanelesButton) {
         nextToPanelesButton.addEventListener('click', () => {
-            // Si el modo de consumo por factura está activo, lee y guarda los datos primero.
-            if (userSelections.metodoIngresoConsumoEnergia === 'boletaMensual') {
+            if (userSelections.metodoIngresoConsumoEnergia === 'promedioMensual') {
+                const promedioInput = document.getElementById('consumo-promedio-mes');
+                if (promedioInput) {
+                    const promedioValue = parseFloat(promedioInput.value) || 0;
+                    userSelections.totalAnnualConsumption = promedioValue * 12;
+                    userSelections.totalMonthlyConsumption = promedioValue;
+                }
+            } else if (userSelections.metodoIngresoConsumoEnergia === 'boletaMensual') {
                 const monthIds = [
                     'consumo-enero', 'consumo-febrero', 'consumo-marzo', 'consumo-abril',
                     'consumo-mayo', 'consumo-junio', 'consumo-julio', 'consumo-agosto',


### PR DESCRIPTION
This commit modifies the energy consumption form for basic, commercial, and SME users. The 12 monthly input fields have been replaced with a single input field for average monthly consumption, as requested by the user.

Changes include:
- Added a new section in `calculador.html` for the single input field.
- Updated `calculador.js` to conditionally display the new section based on the user type.
- Updated `calculador.js` to calculate the total annual consumption from the new average monthly consumption input.