### PR TITLE
fix: Prevent default action on navigation button

### DIFF
--- a/calculador.js
+++ b/calculador.js
@@ -2199,7 +2199,8 @@ function setupNavigationButtons() {
         }
     });
 
-    document.getElementById('next-to-energia')?.addEventListener('click', () => {
+    document.getElementById('next-to-energia')?.addEventListener('click', (event) => {
+        event.preventDefault();
         const selectedZona = document.querySelector('input[name="zonaInstalacionNewScreen"]:checked');
         if (selectedZona) {
             userSelections.selectedZonaInstalacion = selectedZona.value;


### PR DESCRIPTION
This commit fixes a bug where the "Siguiente" button in the expert user flow would not navigate to the next section. The button's click handler has been updated to prevent the browser's default submit action from interfering with the navigation logic.