### PR TITLE
Fix: Correct expert user navigation flow

### DIFF
--- a/calculador.html
+++ b/calculador.html
@@ -750,7 +750,7 @@
                     </div>
                     <div class="form-actions">
                         <button type="button" id="back-to-map-from-zona" class="back-button">Atrás</button>
-                        <button type="submit" id="next-to-energia">Siguiente</button>
+                        <button type="submit" id="next-from-zona">Siguiente</button>
                     </div>
                 </div>
                 <!-- Nueva sección para Superficie Rodea -->

--- a/calculador.js
+++ b/calculador.js
@@ -2199,7 +2199,7 @@ function setupNavigationButtons() {
         }
     });
 
-    document.getElementById('next-to-energia')?.addEventListener('click', (event) => {
+    document.getElementById('next-from-zona')?.addEventListener('click', (event) => {
         event.preventDefault();
         const selectedZona = document.querySelector('input[name="zonaInstalacionNewScreen"]:checked');
         if (selectedZona) {


### PR DESCRIPTION
The "next" button on the "zona de instalacion" screen was not working for expert users. This was due to a non-specific button ID that was likely causing conflicts.

This change renames the button ID in `calculador.html` from `next-to-energia` to `next-from-zona` and updates the corresponding event listener in `calculador.js` to use the new, more specific ID. This ensures the button works as expected, allowing the expert user to proceed to the next step in the form.