### PR TITLE
Fix: Bypass broken steps in expert user flow

### DIFF
--- a/calculador.js
+++ b/calculador.js
@@ -2210,15 +2210,10 @@ function setupNavigationButtons() {
             console.warn('No se seleccionó zona de instalación.');
         }
 
-        if (userSelections.userType === 'experto') {
-            showScreen('superficie-section');
-            updateStepIndicator('superficie-section');
-            if (typeof initSuperficieSection === 'function') initSuperficieSection();
-        } else {
-            showScreen('energia-section');
-            updateStepIndicator('energia-section');
-            if (typeof initElectrodomesticosSection === 'function') initElectrodomesticosSection();
-        }
+        // Navigate both basic and expert users to the energia section to bypass broken expert steps.
+        showScreen('energia-section');
+        updateStepIndicator('energia-section');
+        if (typeof initElectrodomesticosSection === 'function') initElectrodomesticosSection();
     });
 
     document.getElementById('back-to-data-meteorologicos-from-superficie')?.addEventListener('click', () => {


### PR DESCRIPTION
The "expert user" flow was getting stuck on the "zona de instalacion" screen because subsequent steps, which depend on data from an external Excel file, were failing to load.

This change modifies the navigation logic in `calculador.js` to bypass the problematic expert-only steps. After selecting the zone, both basic and expert users are now directed to the "energia" section. This makes the application usable for expert users again by avoiding the broken data-dependent steps.