### PR TITLE
feat: Implement all expert report calculations

### DIFF
--- a/backend/engine.py
+++ b/backend/engine.py
@@ -138,6 +138,15 @@ def run_calculation_engine(user_data, excel_path):
 
         if user_data.get("userType") == "experto":
             print("Calculating expert user report data...")
+
+            def get_value(df, row, col, is_numeric=False):
+                val = df.iloc[row, col]
+                if pd.isna(val):
+                    return 0 if is_numeric else ""
+                if is_numeric:
+                    return pd.to_numeric(val, errors='coerce')
+                return str(val)
+
             radiacion_anual_incidente = to_numeric_safe(df_datos_entrada.iloc[19:31, 13].sum())
             incremento_plano_horizontal = to_numeric_safe(df_datos_entrada.iloc[35, 15])
             consumo_anual_energia = to_numeric_safe(df_datos_entrada.iloc[66, 2])
@@ -147,6 +156,53 @@ def run_calculation_engine(user_data, excel_path):
                 "incremento_plano_horizontal": incremento_plano_horizontal,
                 "consumo_anual_energia_electrica": consumo_anual_energia,
             }
+
+            panel_details = {
+                "marca": get_value(df_ingreso_datos, 86, 1),
+                "potencia": get_value(df_ingreso_datos, 89, 1, is_numeric=True),
+                "modelo": get_value(df_ingreso_datos, 91, 1),
+                "eficiencia": get_value(df_datos_entrada, 83, 3, is_numeric=True),
+                "cantidad_paneles": get_value(df_datos_entrada, 105, 2, is_numeric=True),
+                "superficie_necesaria": get_value(df_datos_entrada, 85, 3, is_numeric=True),
+                "potencia_instalada": get_value(df_datos_entrada, 107, 2, is_numeric=True),
+            }
+            expert_data["panel_details"] = panel_details
+
+            inverter_details = {
+                "inversores_sugeridos": get_value(df_ingreso_datos, 99, 1),
+                "potencia": get_value(df_datos_entrada, 115, 2, is_numeric=True),
+                "modelo": get_value(df_datos_entrada, 116, 2),
+                "inversor": get_value(df_datos_entrada, 117, 2),
+                "eficiencia": get_value(df_datos_entrada, 119, 3, is_numeric=True),
+                "cantidad": get_value(df_datos_entrada, 121, 2, is_numeric=True),
+            }
+            expert_data["inverter_details"] = inverter_details
+
+            c35 = to_numeric_safe(df_resultados.iloc[34, 2])
+            c36 = to_numeric_safe(df_resultados.iloc[35, 2])
+            c38 = to_numeric_safe(df_resultados.iloc[37, 2])
+            c39 = to_numeric_safe(df_resultados.iloc[38, 2])
+            c41 = to_numeric_safe(df_resultados.iloc[40, 2])
+
+            c117 = to_numeric_safe(df_datos_entrada.iloc[116, 2])
+            c118 = to_numeric_safe(df_datos_entrada.iloc[117, 2])
+            c119 = to_numeric_safe(df_datos_entrada.iloc[118, 2])
+            c120 = to_numeric_safe(df_datos_entrada.iloc[119, 2])
+
+            ahorro_neto_label = "Si realiza la instalación fotovoltaica tendrá un saldo neto anual a su favor de " if c120 > 0 else "Si realiza la instalación fotovoltaica su costo anual en energía eléctrica se reducirá a "
+            ahorro_neto_valor = c119 - c118 - c117
+
+            economic_details = {
+                "costo_actual_anual": c35,
+                "costo_mantenimiento_anual": c36,
+                "costo_futuro_energia": c38,
+                "ingreso_anual_inyeccion": c39,
+                "inversion_inicial": c41,
+                "ahorro_neto_label": ahorro_neto_label,
+                "ahorro_neto_valor": ahorro_neto_valor
+            }
+            expert_data["economic_details"] = economic_details
+
             final_report["expert_data"] = expert_data
             print(f"Expert data calculated: {expert_data}")
 

--- a/informe.html
+++ b/informe.html
@@ -351,7 +351,7 @@
             </table>
             <div class="section-header" style="font-size: 1.1rem; background: none; color: #333;">Resultado económico actualizado del proyecto</div>
             <table class="report-table">
-                <tr><td>Ahorro neto logrado durante la vida util del proyecto</td><td><span id="experto_moneda_12"></span> <span id="experto_ahorro_neto"></span></td></tr>
+                <tr><td id="experto_ahorro_neto_label">Ahorro neto logrado durante la vida util del proyecto</td><td><span id="experto_moneda_12"></span> <span id="experto_ahorro_neto"></span></td></tr>
             </table>
         </div>
         <!-- Emisiones -->

--- a/informe.js
+++ b/informe.js
@@ -68,37 +68,47 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (userType === 'experto') {
         const techData = datos.technical_data || {};
-        const panelDetails = techData.panel_details || {};
-        const inverterDetails = techData.inverter_details || {};
-
         const expertData = datos.expert_data || {};
-        // Populate Expert Report from expert_data
+        const panelDetails = expertData.panel_details || {};
+        const inverterDetails = expertData.inverter_details || {};
+        const economicDetails = expertData.economic_details || {};
+
+        // Populate Radiacion and Consumo
         setTextContent('experto_radiacion_anual', formatNumber(expertData.radiacion_anual_incidente, 2));
         setTextContent('experto_incremento_radiacion', formatNumber(expertData.incremento_plano_horizontal * 100, 2));
         setTextContent('experto_consumo_anual', formatNumber(expertData.consumo_anual_energia_electrica, 0));
 
-        setTextContent('experto_panel_marca', panelDetails['Marca'] || 'N/A');
-        setTextContent('experto_panel_potencia', panelDetails['Potencia'] || 'N/A');
-        setTextContent('experto_panel_modelo', panelDetails['Modelo'] || 'N/A');
-        setTextContent('experto_panel_eficiencia', `${formatNumber(panelDetails['Eficiencia informada por el fabricante del panel'], 2)} %` || 'N/A');
-        setTextContent('experto_cantidad_paneles', panelDetails['Cantidad Paneles Necesarios'] || 'N/A');
-        setTextContent('experto_superficie', `${formatNumber(panelDetails['Superficie necesaria'], 2)} m²` || 'N/A');
-        setTextContent('experto_potencia_instalada', `${formatNumber(panelDetails['Potencia Instalada Wp'], 0)} Wp` || 'N/A');
+        // Populate Panel Details
+        setTextContent('experto_panel_marca', panelDetails.marca || 'N/A');
+        setTextContent('experto_panel_potencia', panelDetails.potencia || 'N/A');
+        setTextContent('experto_panel_modelo', panelDetails.modelo || 'N/A');
+        setTextContent('experto_panel_eficiencia', `${formatNumber(panelDetails.eficiencia * 100, 2)} %`);
+        setTextContent('experto_cantidad_paneles', panelDetails.cantidad_paneles || 'N/A');
+        setTextContent('experto_superficie', `${formatNumber(panelDetails.superficie_necesaria, 2)} m²`);
+        setTextContent('experto_potencia_instalada', `${formatNumber(panelDetails.potencia_instalada, 0)} W`);
 
-        setTextContent('experto_inversor_sugerido', inverterDetails['Inversores sugeridos'] || 'N/A');
-        setTextContent('experto_inversor_potencia', `${formatNumber(inverterDetails['Potencia'], 0)} W` || 'N/A');
-        setTextContent('experto_inversor_eficiencia', `${formatNumber(inverterDetails['Eficiencia informada por el fabricante del INVERSOR'], 2)} %` || 'N/A');
-        setTextContent('experto_cantidad_inversores', inverterDetails['Cantidad de Inversores'] || 'N/A');
+        // Populate Inverter Details
+        const sugeridos = inverterDetails.inversores_sugeridos || 'N/A';
+        const modelo = inverterDetails.modelo || 'N/A';
+        const inversor = inverterDetails.inversor || 'N/A';
+        setTextContent('experto_inversor_sugerido', `${sugeridos} (Modelo: ${modelo}, Inversor: ${inversor})`);
+        setTextContent('experto_inversor_potencia', `${formatNumber(inverterDetails.potencia, 0)} W`);
+        setTextContent('experto_inversor_eficiencia', `${formatNumber(inverterDetails.eficiencia * 100, 2)} %`);
+        setTextContent('experto_cantidad_inversores', inverterDetails.cantidad || 'N/A');
 
-
-        // Economic data from main report object
+        // Populate Economic Details
         document.querySelectorAll('[id^="experto_moneda_"]').forEach(el => el.textContent = monedaSimbolo);
-        setTextContent('experto_costo_actual', formatNumber(datos.costo_actual, 0));
-        setTextContent('experto_inversion_inicial', formatNumber(datos.inversion_inicial, 0));
-        setTextContent('experto_mantenimiento', formatNumber(datos.mantenimiento, 0));
-        setTextContent('experto_costo_futuro', formatNumber(datos.costo_futuro, 0));
-        setTextContent('experto_ingreso_anual_inyeccion', formatNumber(datos.ingreso_red, 0));
-        setTextContent('experto_ahorro_neto', formatNumber(datos.ahorro_total, 0));
+        setTextContent('experto_costo_actual', formatNumber(economicDetails.costo_actual_anual, 0));
+        setTextContent('experto_inversion_inicial', formatNumber(economicDetails.inversion_inicial, 0));
+        setTextContent('experto_mantenimiento', formatNumber(economicDetails.costo_mantenimiento_anual, 0));
+        setTextContent('experto_costo_futuro', formatNumber(economicDetails.costo_futuro_energia, 0));
+        setTextContent('experto_ingreso_anual_inyeccion', formatNumber(economicDetails.ingreso_anual_inyeccion, 0));
+
+        const ahorroNetoLabel = document.getElementById('experto_ahorro_neto_label');
+        if (ahorroNetoLabel) {
+            ahorroNetoLabel.textContent = economicDetails.ahorro_neto_label || "Ahorro neto logrado durante la vida util del proyecto";
+        }
+        setTextContent('experto_ahorro_neto', formatNumber(economicDetails.ahorro_neto_valor, 0));
 
         // Emissions
         setTextContent('experto_emisiones_primer_ano', formatNumber(datos.emisiones_evitadas_primer_ano_tco2, 2));


### PR DESCRIPTION
This commit implements all the remaining calculations for the expert user report, based on the formulas provided by the user.

- Adds logic to `backend/engine.py` to calculate:
  - Radiación Anual Incidente, Incremento respecto de un plano horizontal, and Consumo anual de energía eléctrica.
  - Panel details (Marca, Potencia, Modelo, etc.).
  - Inverter details.
  - Economic details, including a conditional label.
- The results are stored in a structured `expert_data` dictionary within the main report payload.
- Updates `informe.js` to correctly parse the `expert_data` object and populate all the corresponding fields in the expert report section.
- Adds a new ID to a `<td>` in `informe.html` to support the conditional economic label.