### PR TITLE
Fix frontend crash in expert mode and provide Gunicorn config

### DIFF
--- a/GUNICORN_DEPLOYMENT.md
+++ b/GUNICORN_DEPLOYMENT.md
@@ -1,0 +1,98 @@
+# Instrucciones para Despliegue de Gunicorn con systemd y OpenLiteSpeed
+
+Este documento proporciona una guía para configurar Gunicorn como un servicio de `systemd` y conectarlo con OpenLiteSpeed como un proxy inverso. Esta configuración es robusta y previene los errores de "address already in use".
+
+## 1. Instalar Dependencias
+
+Asegúrate de que todas las dependencias, incluyendo `gunicorn` y `sdnotify`, estén instaladas en tu entorno virtual.
+
+```bash
+pip install -r requirements.txt
+```
+
+## 2. Configurar el Servicio de systemd
+
+He creado un archivo de plantilla llamado `controlador-solar.service`. Este archivo debe ser modificado y luego copiado a `/etc/systemd/system/`.
+
+**Contenido de `controlador-solar.service`:**
+```ini
+[Unit]
+Description=Gunicorn instance to serve a Flask application
+After=network.target
+
+[Service]
+# Reemplaza 'your_user' con tu nombre de usuario en el servidor
+User=your_user
+Group=your_user
+
+# Reemplaza con la ruta absoluta a la raíz de tu proyecto
+WorkingDirectory=/path/to/your/project/root
+
+# Comando para iniciar Gunicorn (usando un socket Unix)
+# Asegúrate de que la ruta a gunicorn sea la correcta para tu entorno virtual
+ExecStart=/path/to/your/project/root/venv/bin/gunicorn --workers 3 --worker-class gthread --threads 4 --bind unix:controlador-solar.sock wsgi:app
+
+# Si prefieres usar un puerto TCP en lugar de un socket:
+# ExecStart=/path/to/your/project/root/venv/bin/gunicorn --workers 3 --bind 127.0.0.1:5000 wsgi:app
+
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+```
+
+### Pasos para la instalación:
+
+1.  **Edita el archivo:**
+    *   Cambia `User=your_user` y `Group=your_user` por tu usuario y grupo en el VPS.
+    *   Cambia `WorkingDirectory=/path/to/your/project/root` a la ruta absoluta de tu proyecto (ej. `/home/calculadorsolar.soyloregonzalez.com/`).
+    *   Asegúrate de que la ruta en `ExecStart` a `gunicorn` sea la correcta (dentro de tu `venv`).
+
+2.  **Copia el archivo al directorio de systemd:**
+    ```bash
+    sudo cp controlador-solar.service /etc/systemd/system/controlador-solar.service
+    ```
+
+3.  **Recarga, inicia y habilita el servicio:**
+    ```bash
+    sudo systemctl daemon-reload
+    sudo systemctl start controlador-solar
+    sudo systemctl enable controlador-solar
+    ```
+
+4.  **Verifica el estado del servicio:**
+    ```bash
+    sudo systemctl status controlador-solar
+    ```
+    Deberías ver que está "active (running)".
+
+## 3. Configurar OpenLiteSpeed como Proxy Inverso
+
+La configuración del proxy en OpenLiteSpeed debe apuntar al socket de Gunicorn.
+
+### Si usas un Socket Unix (Recomendado):
+
+En la configuración de tu VirtualHost en OpenLiteSpeed, actualiza el contexto para que apunte al socket. La ruta al socket es relativa al `WorkingDirectory` que definiste en el archivo de servicio.
+
+```
+context /api {
+  type    proxy
+  address unix:///path/to/your/project/root/controlador-solar.sock
+  keepAlive 1
+}
+```
+**Importante:** Reemplaza `/path/to/your/project/root/` con la ruta real. OpenLiteSpeed necesita permisos para acceder al archivo del socket. Asegúrate de que el usuario con el que corre OpenLiteSpeed (normalmente `nobody` o `litespeed`) pueda acceder al socket.
+
+### Si usas un Puerto TCP:
+
+Si decidiste usar `bind 127.0.0.1:5000` en el archivo de servicio, tu configuración actual de OpenLiteSpeed es correcta:
+
+```
+context /api {
+  type    proxy
+  address 127.0.0.1:5000
+  keepAlive 1
+}
+```
+
+Al seguir estos pasos, tendrás una única instancia de Gunicorn gestionada correctamente por `systemd`, lo que resolverá los problemas de puertos y asegurará que la aplicación se reinicie automáticamente si falla.

--- a/calculador.js
+++ b/calculador.js
@@ -867,8 +867,8 @@ function initPanelesSectionExpert() {
     console.log('[DEBUG] panelModeloTemperaturaSubform:', typeof panelModeloTemperaturaSubform !== 'undefined' ? panelModeloTemperaturaSubform : 'NOT DEFINED');
     // panelCantidadExpertSubform was removed, ensure it's not referenced.
 
-    if (!panelMarcaSubform || !panelPotenciaSubform || !panelModeloSubform || !panelModeloTemperaturaSubform) {
-        console.error("Uno o más contenedores de sub-formularios de Paneles no fueron encontrados en initPanelesSectionExpert. panelMarcaSubform:", panelMarcaSubform, "panelPotenciaSubform:", panelPotenciaSubform, "panelModeloSubform:", panelModeloSubform, "panelModeloTemperaturaSubform:", panelModeloTemperaturaSubform);
+    if (!panelMarcaSubform || !panelPotenciaSubform || !panelModeloSubform) {
+        console.error("Uno o más contenedores de sub-formularios de Paneles no fueron encontrados en initPanelesSectionExpert. panelMarcaSubform:", panelMarcaSubform, "panelPotenciaSubform:", panelPotenciaSubform, "panelModeloSubform:", panelModeloSubform);
         return;
     }
 
@@ -877,7 +877,8 @@ function initPanelesSectionExpert() {
     panelPotenciaSubform.style.display = 'none';
     // panelCantidadExpertSubform was removed
     panelModeloSubform.style.display = 'none';
-    panelModeloTemperaturaSubform.style.display = 'none';
+    // panelModeloTemperaturaSubform is part of the "Perdidas" section, so it should not be hidden here.
+    // panelModeloTemperaturaSubform.style.display = 'none';
     console.log('[DEBUG] initPanelesSectionExpert: All panel sub-forms hidden.');
 
     console.log('[DEBUG] initPanelesSectionExpert: Attempting to show panelMarcaSubform.');

--- a/controlador-solar.service
+++ b/controlador-solar.service
@@ -1,0 +1,34 @@
+[Unit]
+Description=Gunicorn instance to serve a Flask application
+After=network.target
+
+[Service]
+# User and Group that will run the service
+# Replace 'your_user' with the actual username on the server
+User=your_user
+Group=your_user
+
+# Working directory
+# Replace with the absolute path to the project root on the server
+# e.g., /home/your_user/calculador-solar
+WorkingDirectory=/path/to/your/project/root
+
+# Environment variables (if any)
+# Environment="FLASK_ENV=production"
+
+# Command to start the Gunicorn server
+# --workers 3: A good starting point is (2 * number_of_cpu_cores) + 1. Adjust as needed.
+# --bind unix:controlador-solar.sock: Binds to a Unix socket. This is generally safer and slightly more performant than a TCP port (like 127.0.0.1:5000) when Gunicorn and the web server (OpenLiteSpeed) are on the same machine. The web server's proxy configuration will need to point to this socket file.
+# --worker-class gthread: Using threaded workers.
+# --threads 4: Number of threads per worker.
+# wsgi:app: The entry point to the application (the 'app' object in 'wsgi.py').
+ExecStart=/path/to/your/project/root/venv/bin/gunicorn --workers 3 --worker-class gthread --threads 4 --bind unix:controlador-solar.sock wsgi:app
+
+# If you prefer to stick with a TCP port instead of a socket:
+# ExecStart=/path/to/your/project/root/venv/bin/gunicorn --workers 3 --bind 127.0.0.1:5000 wsgi:app
+
+# Restart policy
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ flask-cors
 pandas
 openpyxl
 tabulate
+sdnotify


### PR DESCRIPTION
This commit addresses several issues with the Solar Calculator application.

1.  **Frontend Fix for Expert Mode:**
    - The "expert mode" page was appearing blank due to a JavaScript error that halted script execution.
    - The `initPanelesSectionExpert` function in `calculador.js` contained faulty logic that referenced an element (`panel-modelo-temperatura-subform`) that was part of a different UI section. It also had the unintended side effect of hiding this element.
    - The code has been corrected to remove this faulty check and the side effect, making the script more robust and preventing the crash.

2.  **Gunicorn `systemd` Configuration:**
    - To resolve the "address already in use" errors, a template `systemd` service file (`controlador-solar.service`) has been added.
    - A detailed guide, `GUNICORN_DEPLOYMENT.MD`, explains how to configure the service for a stable production deployment using a Unix socket or a TCP port.
    - The `sdnotify` package was added to `requirements.txt` to support this improved service configuration.

3.  **Backend Validation:**
    - The backend was tested locally. The `/api/electrodomesticos` and `/api/superficie_options` endpoints were queried and confirmed to be returning valid JSON data.
    - This confirms that the backend can correctly access both the `consumos_electrodomesticos.json` file and the main Excel data file, ruling out backend data access as a source of the errors.