### PR TITLE
Fix(backend): Remove incorrect decimal separator in pandas read_excel

### DIFF
--- a/backend/backend.py
+++ b/backend/backend.py
@@ -138,7 +138,7 @@ def get_superficie_options():
         print(f"DEBUG: Solicitud a /api/superficie_options. Leyendo de HOJA 'Tablas' desde: {EXCEL_FILE_PATH}")
         # Usamos decimal=',' por si los números en la hoja 'Tablas' usan coma decimal.
         # Si esta parte específica de la hoja usa punto decimal, se puede omitir.
-        df_tablas = pd.read_excel(EXCEL_FILE_PATH, sheet_name='Tablas', engine='openpyxl', decimal=',')
+        df_tablas = pd.read_excel(EXCEL_FILE_PATH, sheet_name='Tablas', engine='openpyxl')
         print("DEBUG: Hoja 'Tablas' leída para opciones de superficie.")
 
         # Column M (descripción) es índice 12, Column N (valor) es índice 13
@@ -211,7 +211,7 @@ def get_superficie_options():
 def get_rugosidad_options():
     try:
         print(f"DEBUG: Solicitud a /api/rugosidad_options. Leyendo de HOJA 'Tablas' desde: {EXCEL_FILE_PATH}")
-        df_tablas = pd.read_excel(EXCEL_FILE_PATH, sheet_name='Tablas', engine='openpyxl', decimal=',')
+        df_tablas = pd.read_excel(EXCEL_FILE_PATH, sheet_name='Tablas', engine='openpyxl')
         print("DEBUG: Hoja 'Tablas' leída para opciones de rugosidad.")
 
         col_desc_idx = 12  # Columna M
@@ -280,7 +280,7 @@ def get_rugosidad_options():
 def get_rotacion_options():
     try:
         print(f"DEBUG: Solicitud a /api/rotacion_options. Leyendo de HOJA 'Tablas' desde: {EXCEL_FILE_PATH}")
-        df_tablas = pd.read_excel(EXCEL_FILE_PATH, sheet_name='Tablas', engine='openpyxl', decimal=',')
+        df_tablas = pd.read_excel(EXCEL_FILE_PATH, sheet_name='Tablas', engine='openpyxl')
         print("DEBUG: Hoja 'Tablas' leída para opciones de rotación.")
 
         col_desc_idx = 15  # Columna P


### PR DESCRIPTION
The `pd.read_excel` calls for reading the 'Tablas' sheet were using the `decimal=','` parameter. This caused a `ValueError` when parsing floating-point numbers from the Excel file, as the file uses periods as decimal separators.

This commit removes the `decimal=','` parameter from the `pd.read_excel` calls in the `get_superficie_options`, `get_rugosidad_options`, and `get_rotacion_options` functions in `backend/backend.py`.

This fixes the issue where the frontend would show an "Error al cargar las opciones de superficie" alert because the backend API endpoint was crashing.