### PR TITLE
feat: Display energy categories in a 3-column grid

### DIFF
--- a/calculador.html
+++ b/calculador.html
@@ -423,6 +423,9 @@
 
         /* Styles for Electrodomesticos List */
         #electrodomesticos-list {
+            display: grid;
+            grid-template-columns: repeat(3, 1fr);
+            gap: 1rem;
             background-color: #f9f9f9;
             border-radius: 8px;
             padding: 1rem;


### PR DESCRIPTION
This change modifies the layout of the 'Energía de Usuario Básico Residencial' section to display the appliance categories in a three-column grid.

The CSS for the `#electrodomesticos-list` element has been updated to use a grid layout, which addresses the user's request to fit more content on the screen and improve the visual organization.