### PR TITLE
fix: Update cache-busting string to ensure changes are visible

### DIFF
--- a/calculador.html
+++ b/calculador.html
@@ -7,7 +7,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Dosis:wght@400;500;700&family=Bebas+Neue&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
     <link rel="stylesheet" href="https://unpkg.com/leaflet-control-geocoder/dist/Control.Geocoder.css">
-    <link rel="stylesheet" href="./styles.css?v=prod1">
+    <link rel="stylesheet" href="./styles.css?v=prod2">
     <style>
         :root {
             --color-primary: #FF8442;
@@ -1060,7 +1060,7 @@
 
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
     <script src="https://unpkg.com/leaflet-control-geocoder/dist/Control.Geocoder.js"></script>
-    <script src="calculador.js?v=prod1" defer></script>
+    <script src="calculador.js?v=prod2" defer></script>
 
     <footer>
         <div class="footer-logos">


### PR DESCRIPTION
The previous change to a 3-column layout was not visible to the user due to browser caching. This commit updates the cache-busting query string in `calculador.html` for both the CSS and JavaScript files. This will force browsers to download the new versions of the files.