### PR TITLE
fix: Correctly apply grid styles in JavaScript

### DIFF
--- a/calculador.js
+++ b/calculador.js
@@ -1260,13 +1260,6 @@ function initElectrodomesticosSection() {
         return;
     }
 
-    // Apply grid styles directly to the container for the 3-column layout
-    if (listContainer) {
-        listContainer.style.display = 'grid';
-        listContainer.style.gridTemplateColumns = 'repeat(3, 1fr)';
-        listContainer.style.gap = '1rem';
-    }
-
     // Default states
     modoSeleccionContainer.style.display = 'none';
     listContainer.innerHTML = ''; // Clear previous content from list area
@@ -1387,8 +1380,14 @@ function initElectrodomesticosSection() {
         // }
         // END: Add help text
 
-        listContainer.style.display = 'block'; // Show appliance list container
+        // listContainer.style.display = 'block'; // <<< THIS WAS THE BUG. REMOVED.
         if (summaryContainer) summaryContainer.style.display = 'flex'; // Show summary
+
+        // NEW: Apply grid styles for the 3-column layout
+        listContainer.style.display = 'grid';
+        listContainer.style.gridTemplateColumns = 'repeat(3, 1fr)';
+        listContainer.style.gap = '1rem';
+
         populateStandardApplianceList(listContainer); // Populate it with appliances
         // consumoFacturaSection is already hidden by default state above
         }


### PR DESCRIPTION
This commit applies the definitive fix for the three-column layout feature.

The previous JavaScript implementation had a bug where `listContainer.style.display = 'block'` was overriding the intended `display: grid` style. This commit removes the incorrect line and applies the grid styles in the correct conditional block, ensuring they are applied only for the "Basic Residencial" user type and are not overridden.

This resolves the issue where the layout changes were not appearing despite the code being present on the server.