### PR TITLE
feat: Unify appliance list layout for all user types

### DIFF
--- a/calculador.js
+++ b/calculador.js
@@ -1282,7 +1282,11 @@ function initElectrodomesticosSection() {
 
             if (choice === 'detalleHogar') {
                 if (summaryContainer) summaryContainer.style.display = 'flex';
-                if (electrodomesticosList) electrodomesticosList.style.display = 'block';
+                if (electrodomesticosList) {
+                    electrodomesticosList.style.display = 'grid';
+                    electrodomesticosList.style.gridTemplateColumns = 'repeat(3, 1fr)';
+                    electrodomesticosList.style.gap = '1rem';
+                }
                 populateStandardApplianceList(listContainer);
             } else if (choice === 'boletaMensual') {
                 if (consumoFacturaForm) consumoFacturaForm.style.display = 'block';


### PR DESCRIPTION
This change modifies the `calculador.js` file to ensure the appliance list for the advanced residential user (`detalleHogar` option) uses the same three-column grid layout as the basic user's view.

The `electrodomesticosList` container now has its display style set to 'grid' with three columns and a gap, providing a consistent user experience across different user paths as requested.