### PR TITLE
Expose basic report Excel table in informe view

### DIFF
--- a/backend/engine.py
+++ b/backend/engine.py
@@ -127,13 +127,26 @@ def run_calculation_engine(user_data, excel_path):
             "summer_daily_generation": [generacion_anual/365/24 * 1.5] * 24, # Simplified summer generation
         }
 
+        basic_report_table = []
+        if df_resultados is not None:
+            try:
+                basic_table_df = df_resultados.iloc[2:56, 1:12]
+                basic_report_table = basic_table_df.where(pd.notna(basic_table_df), None).values.tolist()
+            except Exception as table_error:
+                print(f"WARN: Unable to extract basic report table: {table_error}")
+        else:
+            print("WARN: 'Resultados' sheet not found. Basic report table will be empty.")
+
         final_report = {
             "userType": user_data.get("userType", "basico"),
             "moneda": user_data.get("selectedCurrency", "Dólares"),
             "emisiones_evitadas_total_tco2": emisiones_total,
             "technical_data": tech_data,
             "economic_data": economic_data,
-            "chart_data": chart_data
+            "chart_data": chart_data,
+            "basic_report": {
+                "excel_table": basic_report_table
+            }
         }
 
         print("--- Engine Finished Successfully ---")

--- a/informe.html
+++ b/informe.html
@@ -60,6 +60,9 @@
       background-color: #f2f2f2;
       font-weight: bold;
     }
+    .basic-excel-table td {
+      white-space: normal;
+    }
     .result-blue {
       color: #007bff;
       font-weight: bold;
@@ -178,6 +181,12 @@
 
     <!-- Basic User Report Sections -->
     <div id="basic-report-sections">
+        <div class="report-section">
+          <div class="section-header">Resultados completos del informe básico</div>
+          <table class="report-table basic-excel-table">
+            <tbody id="basico_resultados_excel_body"></tbody>
+          </table>
+        </div>
         <div class="report-section">
           <div class="section-header">• Consumo y generación</div>
           <table class="report-table">

--- a/informe.js
+++ b/informe.js
@@ -107,6 +107,9 @@ document.addEventListener('DOMContentLoaded', () => {
     } else { // Basic user
         const economicData = datos.economic_data || {};
         const techData = datos.technical_data || {};
+        const basicReportData = datos.basic_report && datos.basic_report.excel_table ? datos.basic_report.excel_table : [];
+
+        renderBasicExcelTable(basicReportData);
 
         // Technical Data
         setTextContent('basico_consumo_anual_kwh', formatNumber(techData.consumo_anual_kwh, 0));
@@ -161,6 +164,59 @@ document.addEventListener('DOMContentLoaded', () => {
         html2pdf().set(opt).from(element).save();
     });
 });
+
+function renderBasicExcelTable(tableData) {
+    const tbody = document.getElementById('basico_resultados_excel_body');
+    if (!tbody) {
+        return;
+    }
+
+    tbody.innerHTML = '';
+
+    if (!Array.isArray(tableData) || tableData.length === 0) {
+        const emptyRow = document.createElement('tr');
+        const emptyCell = document.createElement('td');
+        emptyCell.colSpan = 11;
+        emptyCell.textContent = 'No se encontraron datos para mostrar el informe básico detallado.';
+        emptyRow.appendChild(emptyCell);
+        tbody.appendChild(emptyRow);
+        return;
+    }
+
+    const columnCount = Array.isArray(tableData[0]) ? tableData[0].length : 1;
+
+    tableData.forEach((row) => {
+        const tr = document.createElement('tr');
+        const normalizedRow = Array.isArray(row) ? row : [row];
+
+        normalizedRow.forEach((cellValue) => {
+            const td = document.createElement('td');
+            let displayValue = '';
+
+            if (cellValue !== null && cellValue !== undefined) {
+                if (typeof cellValue === 'number') {
+                    let formatted = cellValue.toFixed(6).replace(/\.0+$/, '').replace(/\.?0+$/, '');
+                    if (formatted === '') {
+                        formatted = '0';
+                    }
+                    displayValue = formatted;
+                } else {
+                    displayValue = String(cellValue);
+                }
+            }
+
+            td.textContent = displayValue;
+            tr.appendChild(td);
+        });
+
+        const cellsToPad = columnCount - tr.children.length;
+        for (let i = 0; i < cellsToPad; i += 1) {
+            tr.appendChild(document.createElement('td'));
+        }
+
+        tbody.appendChild(tr);
+    });
+}
 
 function renderCharts(datos, userType, monedaSimbolo) {
     if (!datos) return;

--- a/tests/basicReportExcelTable.test.js
+++ b/tests/basicReportExcelTable.test.js
@@ -1,0 +1,53 @@
+const axios = require('axios');
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+jest.setTimeout(120000);
+
+const API_BASE_URL = 'http://127.0.0.1:5000';
+
+function loadPayload() {
+  const payloadPath = path.join(__dirname, '..', 'test_payload.json');
+  const payload = JSON.parse(fs.readFileSync(payloadPath, 'utf-8'));
+  payload.userType = 'basico';
+  return payload;
+}
+
+test('POST /api/generar_informe incluye la tabla básica del Excel', async () => {
+  const payload = loadPayload();
+
+  const response = await axios.post(`${API_BASE_URL}/api/generar_informe`, payload, {
+    headers: { 'Content-Type': 'application/json' },
+    timeout: 120000,
+  });
+
+  expect(response.status).toBe(200);
+  expect(response.data.basic_report).toBeDefined();
+  expect(Array.isArray(response.data.basic_report.excel_table)).toBe(true);
+
+  const expectedTableJson = execSync(`python - <<'PY'
+import pandas as pd
+import json
+import math
+from pathlib import Path
+
+excel_path = Path('backend') / 'Calculador Solar - web 06-24_con ayuda - modificaciones 2025_5.xlsx'
+df_resultados = pd.read_excel(excel_path, sheet_name='Resultados')
+subset = df_resultados.iloc[2:56, 1:12]
+table = subset.where(pd.notna(subset), None).values.tolist()
+
+def clean_nan(obj):
+    if isinstance(obj, list):
+        return [clean_nan(elem) for elem in obj]
+    if isinstance(obj, float) and math.isnan(obj):
+        return None
+    return obj
+
+print(json.dumps(clean_nan(table), ensure_ascii=False))
+PY
+`, { encoding: 'utf-8' });
+
+  const expectedTable = JSON.parse(expectedTableJson);
+  expect(response.data.basic_report.excel_table).toEqual(expectedTable);
+});


### PR DESCRIPTION
## Summary
- extract the Resultados!B3:L56 range into a basic_report.excel_table payload for /api/generar_informe
- render the new table in informe.html within the basic report layout while keeping the stored response intact
- add a Jest integration test to verify the API table matches the Excel source data

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da7d67c95c83278130d76af0c85673