### PR TITLE
feat: Unify appliance list layout for all user types

### DIFF
--- a/calculador.js
+++ b/calculador.js
@@ -1291,7 +1291,11 @@ function initElectrodomesticosSection() {
             } else if (choice === 'boletaMensual') {
                 if (consumoFacturaForm) consumoFacturaForm.style.display = 'block';
             } else if (choice === 'detalleHogarHoras') {
-                if (electrodomesticosList) electrodomesticosList.style.display = 'block';
+                if (electrodomesticosList) {
+                    electrodomesticosList.style.display = 'grid';
+                    electrodomesticosList.style.gridTemplateColumns = 'repeat(3, 1fr)';
+                    electrodomesticosList.style.gap = '1rem';
+                }
                 populateDetailedApplianceList(listContainer);
             }
         };


### PR DESCRIPTION
This change modifies the `calculador.js` file to ensure the appliance lists for the advanced residential user (`detalleHogar` and `detalleHogarHoras` options) use the same three-column grid layout as the basic user's view.

The `electrodomesticosList` container now has its display style set to 'grid' with three columns and a gap in all relevant views, providing a consistent user experience across different user paths as requested.