### PR TITLE
Expose expert report payload for expert UI

### DIFF
--- a/backend/engine.py
+++ b/backend/engine.py
@@ -21,6 +21,8 @@ EXPERTO_REPORT_CONTRACT: Dict[str, Dict[str, str]] = {
         "panelModel": "Modelo seleccionado de panel según catálogo.",
         "panelPowerW": "Potencia nominal individual del panel en Watts.",
         "projectLifetimeYears": "Horizonte de vida útil utilizado para métricas acumuladas.",
+        "panelBrand": "Marca del panel seleccionado cuando está disponible en el catálogo.",
+        "panelEfficiency": "Eficiencia nominal informada por el fabricante del panel (%).",
     },
     "energy": {
         "annualGenerationKWh": "Energía generada por el sistema en un año (kWh).",
@@ -93,6 +95,61 @@ def run_calculation_engine(user_data, excel_path):
         technical_data = build_legacy_technical_data(system_design, energy_metrics, support_params)
         economic_data_legacy = build_legacy_economic_data(economic_metrics)
 
+        expert_report = {
+            "systemDesign": {
+                key: system_design.get(key)
+                for key in [
+                    "panelCount",
+                    "installedCapacityKWp",
+                    "requiredSurfaceM2",
+                    "panelModel",
+                    "panelPowerW",
+                    "projectLifetimeYears",
+                    "panelBrand",
+                    "panelEfficiency",
+                ]
+            },
+            "energy": {
+                key: energy_metrics.get(key)
+                for key in [
+                    "annualGenerationKWh",
+                    "annualAutoconsumptionKWh",
+                    "annualInjectionKWh",
+                    "annualConsumptionKWh",
+                    "selfConsumptionRatio",
+                    "coverageRatio",
+                    "gridEnergyKWh",
+                ]
+            },
+            "economy": {
+                key: economic_metrics.get(key)
+                for key in [
+                    "preProjectAnnualCost",
+                    "postProjectAnnualCost",
+                    "annualSavings",
+                    "initialInvestment",
+                    "maintenanceAnnualCost",
+                    "injectionRevenue",
+                    "paybackYears",
+                ]
+            },
+            "tariffs": {
+                key: tariffs.get(key)
+                for key in [
+                    "consumptionTariff",
+                    "injectionTariff",
+                    "currency",
+                ]
+            },
+            "emissions": {
+                key: emission_metrics.get(key)
+                for key in [
+                    "avoidedTonsCO2PerYear",
+                    "avoidedTonsCO2Lifetime",
+                ]
+            },
+        }
+
         final_report = {
             "userType": user_data.get("userType", "basico"),
             "moneda": user_data.get("selectedCurrency", "Dólares"),
@@ -106,6 +163,7 @@ def run_calculation_engine(user_data, excel_path):
             "chart_data": chart_data,
             "basic_report": {"excel_table": basic_report_table},
             "expert_contract": deepcopy(EXPERTO_REPORT_CONTRACT),
+            "expert_report": expert_report,
         }
 
         print("--- Engine Finished Successfully ---")
@@ -190,6 +248,13 @@ def calculate_system_design(user_data: Dict, panel_data: Dict, support_params: D
         panel_area_m2 = largo * ancho if largo and ancho else 0
     required_surface = panel_area_m2 * panel_count
 
+    panel_brand = panel_data.get('Marca') or user_data.get('panelesSolares', {}).get('marca')
+
+    panel_efficiency = to_numeric_safe(
+        panel_data.get('Eficiencia informada por el fabricante del panel'),
+        default=None,
+    )
+
     return {
         "panelCount": panel_count,
         "installedCapacityKWp": installed_capacity_kwp,
@@ -197,6 +262,8 @@ def calculate_system_design(user_data: Dict, panel_data: Dict, support_params: D
         "panelModel": panel_data.get('Modelo', user_data.get('panelesSolares', {}).get('modelo', 'Modelo no encontrado')),
         "panelPowerW": panel_power_w,
         "projectLifetimeYears": support_params.get('project_lifetime_years', 25),
+        "panelBrand": panel_brand,
+        "panelEfficiency": panel_efficiency,
     }
 
 

--- a/informe.js
+++ b/informe.js
@@ -40,7 +40,8 @@ document.addEventListener('DOMContentLoaded', () => {
     function setTextContent(id, value) {
         const element = document.getElementById(id);
         if (element) {
-            element.textContent = value;
+            const safeValue = (value === undefined || value === null || value === '') ? 'N/A' : value;
+            element.textContent = safeValue;
         } else {
             console.warn(`Elemento con ID '${id}' no encontrado.`);
         }
@@ -63,46 +64,103 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     // --- Data Population ---
-    const formatNumber = (num, decimals = 2) => num != null ? num.toLocaleString('es-AR', { minimumFractionDigits: decimals, maximumFractionDigits: decimals }) : 'N/A';
+    const formatNumber = (num, decimals = 2) => {
+        if (typeof num !== 'number' || !Number.isFinite(num)) {
+            return 'N/A';
+        }
+        return num.toLocaleString('es-AR', {
+            minimumFractionDigits: decimals,
+            maximumFractionDigits: decimals,
+        });
+    };
     const monedaSimbolo = datos.moneda === 'Dólares' ? 'U$D' : '$';
 
     if (userType === 'experto') {
-        const techData = datos.technical_data || {};
-        const panelDetails = techData.panel_details || {};
-        const inverterDetails = techData.inverter_details || {};
+        const expertReport = datos.expert_report || {
+            systemDesign: datos.system_design || {},
+            energy: datos.energy || {},
+            economy: datos.economy || {},
+            emissions: datos.emissions || {},
+            tariffs: datos.tariffs || {},
+        };
 
-        // Populate Expert Report from technical_data
-        setTextContent('experto_radiacion_anual', `${formatNumber(techData.annual_irradiance, 2)} kWh/m²`);
-        setTextContent('experto_performance_ratio', `${formatNumber(techData.performance_ratio, 2)} %`);
+        const systemDesign = expertReport.systemDesign || {};
+        const energy = expertReport.energy || {};
+        const economy = expertReport.economy || {};
+        const tariffs = expertReport.tariffs || {};
+        const emissions = expertReport.emissions || {};
 
-        setTextContent('experto_consumo_anual', formatNumber(datos.consumo_anual_kwh, 0));
+        const lifetimeYears = (typeof systemDesign.projectLifetimeYears === 'number' && Number.isFinite(systemDesign.projectLifetimeYears))
+            ? systemDesign.projectLifetimeYears
+            : 0;
 
-        setTextContent('experto_panel_marca', panelDetails['Marca'] || 'N/A');
-        setTextContent('experto_panel_potencia', panelDetails['Potencia'] || 'N/A');
-        setTextContent('experto_panel_modelo', panelDetails['Modelo'] || 'N/A');
-        setTextContent('experto_panel_eficiencia', `${formatNumber(panelDetails['Eficiencia informada por el fabricante del panel'], 2)} %` || 'N/A');
-        setTextContent('experto_cantidad_paneles', panelDetails['Cantidad Paneles Necesarios'] || 'N/A');
-        setTextContent('experto_superficie', `${formatNumber(panelDetails['Superficie necesaria'], 2)} m²` || 'N/A');
-        setTextContent('experto_potencia_instalada', `${formatNumber(panelDetails['Potencia Instalada Wp'], 0)} Wp` || 'N/A');
+        const installedCapacityKWp = (typeof systemDesign.installedCapacityKWp === 'number' && Number.isFinite(systemDesign.installedCapacityKWp))
+            ? systemDesign.installedCapacityKWp
+            : null;
+        const installedCapacityW = installedCapacityKWp != null ? installedCapacityKWp * 1000 : null;
 
-        setTextContent('experto_inversor_sugerido', inverterDetails['Inversores sugeridos'] || 'N/A');
-        setTextContent('experto_inversor_potencia', `${formatNumber(inverterDetails['Potencia'], 0)} W` || 'N/A');
-        setTextContent('experto_inversor_eficiencia', `${formatNumber(inverterDetails['Eficiencia informada por el fabricante del INVERSOR'], 2)} %` || 'N/A');
-        setTextContent('experto_cantidad_inversores', inverterDetails['Cantidad de Inversores'] || 'N/A');
+        const requiredSurface = (typeof systemDesign.requiredSurfaceM2 === 'number' && Number.isFinite(systemDesign.requiredSurfaceM2) && systemDesign.requiredSurfaceM2 > 0)
+            ? systemDesign.requiredSurfaceM2
+            : null;
+        const annualIrradiance = (typeof energy.annualGenerationKWh === 'number' && Number.isFinite(energy.annualGenerationKWh) && requiredSurface)
+            ? energy.annualGenerationKWh / requiredSurface
+            : null;
 
+        const totalConsumptionCost = (typeof economy.preProjectAnnualCost === 'number' && Number.isFinite(economy.preProjectAnnualCost) && lifetimeYears)
+            ? economy.preProjectAnnualCost * lifetimeYears
+            : null;
+        const postProjectLifetimeCost = (typeof economy.postProjectAnnualCost === 'number' && Number.isFinite(economy.postProjectAnnualCost) && lifetimeYears)
+            ? economy.postProjectAnnualCost * lifetimeYears
+            : null;
+        const totalSavingsLifetime = (totalConsumptionCost != null && postProjectLifetimeCost != null)
+            ? totalConsumptionCost - postProjectLifetimeCost
+            : null;
+        const netSavingsLifetime = (totalSavingsLifetime != null && typeof economy.initialInvestment === 'number' && Number.isFinite(economy.initialInvestment))
+            ? totalSavingsLifetime - economy.initialInvestment
+            : null;
+        const totalInjectionRevenue = (typeof economy.injectionRevenue === 'number' && Number.isFinite(economy.injectionRevenue) && lifetimeYears)
+            ? economy.injectionRevenue * lifetimeYears
+            : null;
 
-        // Economic data from main report object
+        // Radiación y consumo
+        setTextContent('experto_radiacion_anual', formatNumber(annualIrradiance, 2));
+        setTextContent('experto_incremento_radiacion', 'N/A');
+        setTextContent('experto_consumo_anual', formatNumber(energy.annualConsumptionKWh, 0));
+
+        // Paneles
+        const panelBrand = systemDesign.panelBrand || systemDesign.panelModel || 'N/A';
+        setTextContent('experto_panel_marca', panelBrand);
+        setTextContent('experto_panel_potencia', formatNumber(systemDesign.panelPowerW, 0));
+        setTextContent('experto_panel_modelo', systemDesign.panelModel || 'N/A');
+        setTextContent('experto_panel_eficiencia', formatNumber(systemDesign.panelEfficiency, 2));
+        setTextContent('experto_cantidad_paneles', systemDesign.panelCount);
+        setTextContent('experto_superficie', formatNumber(requiredSurface, 2));
+        setTextContent('experto_potencia_instalada', formatNumber(installedCapacityW, 0));
+
+        // Inversores - no disponibles actualmente en el motor
+        setTextContent('experto_inversor_sugerido', 'No disponible');
+        setTextContent('experto_inversor_potencia', 'N/A');
+        setTextContent('experto_inversor_eficiencia', 'N/A');
+        setTextContent('experto_cantidad_inversores', 'N/A');
+
+        // Datos económicos
         document.querySelectorAll('[id^="experto_moneda_"]').forEach(el => el.textContent = monedaSimbolo);
-        setTextContent('experto_costo_actual', formatNumber(datos.costo_actual, 0));
-        setTextContent('experto_inversion_inicial', formatNumber(datos.inversion_inicial, 0));
-        setTextContent('experto_mantenimiento', formatNumber(datos.mantenimiento, 0));
-        setTextContent('experto_costo_futuro', formatNumber(datos.costo_futuro, 0));
-        setTextContent('experto_ingreso_anual_inyeccion', formatNumber(datos.ingreso_red, 0));
-        setTextContent('experto_ahorro_neto', formatNumber(datos.ahorro_total, 0));
+        setTextContent('experto_cargo_pico', formatNumber(tariffs.consumptionTariff, 4));
+        setTextContent('experto_cargo_fuera_pico', formatNumber(tariffs.consumptionTariff, 4));
+        setTextContent('experto_costo_actual', formatNumber(economy.preProjectAnnualCost, 0));
+        setTextContent('experto_costo_total_actualizado', formatNumber(totalConsumptionCost, 0));
+        setTextContent('experto_inversion_inicial', formatNumber(economy.initialInvestment, 0));
+        setTextContent('experto_mantenimiento', formatNumber(economy.maintenanceAnnualCost, 0));
+        setTextContent('experto_tarifa_inyeccion', formatNumber(tariffs.injectionTariff, 4));
+        setTextContent('experto_costo_futuro', formatNumber(postProjectLifetimeCost, 0));
+        setTextContent('experto_ahorro_actualizado', formatNumber(totalSavingsLifetime, 0));
+        setTextContent('experto_ingreso_anual_inyeccion', formatNumber(economy.injectionRevenue, 0));
+        setTextContent('experto_ingreso_total_inyeccion', formatNumber(totalInjectionRevenue, 0));
+        setTextContent('experto_ahorro_neto', formatNumber(netSavingsLifetime, 0));
 
-        // Emissions
-        setTextContent('experto_emisiones_primer_ano', formatNumber(datos.emisiones_evitadas_primer_ano_tco2, 2));
-        setTextContent('experto_emisiones_totales', formatNumber(datos.emisiones_evitadas_total_tco2, 2));
+        // Emisiones
+        setTextContent('experto_emisiones_primer_ano', formatNumber(emissions.avoidedTonsCO2PerYear, 2));
+        setTextContent('experto_emisiones_totales', formatNumber(emissions.avoidedTonsCO2Lifetime, 2));
 
     } else { // Basic user
         const economicData = datos.economic_data || {};


### PR DESCRIPTION
## Summary
- expose the expert_report section in the engine response so the contrato fields are available for the frontend
- enrich the system design metadata with panel brand and efficiency pulled from the selected catalog entry
- remap the informe experto view to read the new payload, formatting derived economic and emission values for display

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68daa981595c832781ae72d5bdfe60ce