### PR TITLE
Actualizar gráficos expertos con métricas de energy

### DIFF
--- a/informe.js
+++ b/informe.js
@@ -378,6 +378,28 @@ function renderBasicCharts(datos) {
 function renderExpertCharts(datos) {
     console.log("Rendering expert charts with corrected data paths:", datos);
     const techData = datos.technical_data || {};
+    const energyData = {
+        ...(datos.energy || {}),
+        ...(datos.expert_report?.energy || {})
+    };
+
+    const ensureTwelveValues = (arr, fallback = []) => {
+        const source = Array.isArray(arr) ? arr : fallback;
+        const normalized = Array.isArray(source) ? source.slice(0, 12) : [];
+        if (normalized.length >= 12) {
+            return normalized.slice(0, 12);
+        }
+        return normalized.concat(Array(12 - normalized.length).fill(0));
+    };
+
+    const monthlyConsumption = ensureTwelveValues(
+        energyData.monthlyConsumption,
+        datos.consumosMensualesFactura
+    );
+    const monthlyGeneration = ensureTwelveValues(
+        energyData.monthlyGeneration,
+        techData.monthly_generation
+    );
 
     // --- Monthly Balance Bar Chart ---
     const monthlyCtx = document.getElementById('monthlyBalanceChart').getContext('2d');
@@ -387,12 +409,12 @@ function renderExpertCharts(datos) {
         data: {
             labels: monthLabels,
             datasets: [{
-                label: 'Consumo (kWh)',
-                data: datos.consumosMensualesFactura || [],
+                label: 'Consumo mensual (kWh)',
+                data: monthlyConsumption,
                 backgroundColor: 'rgba(255, 99, 132, 0.5)',
             }, {
-                label: 'Generación (kWh)',
-                data: techData.monthly_generation || [],
+                label: 'Generación mensual (kWh)',
+                data: monthlyGeneration,
                 backgroundColor: 'rgba(54, 162, 235, 0.5)',
             }]
         },
@@ -457,8 +479,12 @@ function renderExpertCharts(datos) {
     const years = Array.from({
         length: 25
     }, (_, i) => i + 1);
-    const annualConsumption = datos.consumo_anual_kwh || 0;
-    const annualGenerationStart = techData.annual_generation || 0;
+    const annualConsumption = energyData.annualConsumptionKWh
+        ?? datos.consumo_anual_kwh
+        ?? 0;
+    const annualGenerationStart = energyData.annualGenerationKWh
+        ?? techData.annual_generation
+        ?? 0;
     const degradationRate = 0.005; // 0.5% annual degradation
     const annualGenSeries = years.map(year => annualGenerationStart * Math.pow(1 - degradationRate, year - 1));
 


### PR DESCRIPTION
## Summary
- Reutilizar las series mensuales desde `datos.energy` para los gráficos de balance experto.
- Asegurar que los arreglos mensuales tengan 12 valores y actualizar las etiquetas de los datasets.
- Usar los totales anuales del bloque `energy` como fuente principal de la gráfica de evolución.

## Testing
- Visualización manual de informe experto reciente en `informe.html`.

------
https://chatgpt.com/codex/tasks/task_e_68dab53cd0a48327aed99016592b2d2f