### PR TITLE
Ensure expert report fallbacks use top-level data

### DIFF
--- a/informe.js
+++ b/informe.js
@@ -76,19 +76,30 @@ document.addEventListener('DOMContentLoaded', () => {
     const monedaSimbolo = datos.moneda === 'Dólares' ? 'U$D' : '$';
 
     if (userType === 'experto') {
-        const expertReport = datos.expert_report || {
-            systemDesign: datos.system_design || {},
-            energy: datos.energy || {},
-            economy: datos.economy || {},
-            emissions: datos.emissions || {},
-            tariffs: datos.tariffs || {},
+        const fallbackIfEmpty = (section, fallback) => {
+            if (section && typeof section === 'object' && Object.keys(section).length > 0) {
+                return section;
+            }
+            if (fallback && typeof fallback === 'object' && Object.keys(fallback).length > 0) {
+                return fallback;
+            }
+            return {};
         };
 
-        const systemDesign = expertReport.systemDesign || {};
-        const energy = expertReport.energy || {};
-        const economy = expertReport.economy || {};
-        const tariffs = expertReport.tariffs || {};
-        const emissions = expertReport.emissions || {};
+        const rawExpertReport = datos.expert_report || {};
+        const expertReport = {
+            systemDesign: fallbackIfEmpty(rawExpertReport.systemDesign, datos.system_design),
+            energy: fallbackIfEmpty(rawExpertReport.energy, datos.energy),
+            economy: fallbackIfEmpty(rawExpertReport.economy, datos.economy),
+            emissions: fallbackIfEmpty(rawExpertReport.emissions, datos.emissions),
+            tariffs: fallbackIfEmpty(rawExpertReport.tariffs, datos.tariffs),
+        };
+
+        const systemDesign = fallbackIfEmpty(expertReport.systemDesign, datos.system_design);
+        const energy = fallbackIfEmpty(expertReport.energy, datos.energy);
+        const economy = fallbackIfEmpty(expertReport.economy, datos.economy);
+        const tariffs = fallbackIfEmpty(expertReport.tariffs, datos.tariffs);
+        const emissions = fallbackIfEmpty(expertReport.emissions, datos.emissions);
 
         const lifetimeYears = (typeof systemDesign.projectLifetimeYears === 'number' && Number.isFinite(systemDesign.projectLifetimeYears))
             ? systemDesign.projectLifetimeYears


### PR DESCRIPTION
## Summary
- ensure each expert report section falls back to the top-level engine output when the nested section is empty
- reuse the same fallback guard when reading section data so widgets never receive empty objects

## Testing
- python - <<'PY' # generate cleaned expert report payload for manual verification
- browser_container.run_playwright_script # load informe.html with the generated report and confirm numerical values render

------
https://chatgpt.com/codex/tasks/task_e_68dab53328a48327baf320ae50bf77db