### PR TITLE
Recalculate city-dependent parameters and basic report

### DIFF
--- a/backend/engine.py
+++ b/backend/engine.py
@@ -2,7 +2,8 @@
 
 from copy import deepcopy
 import math
-from typing import Dict, List, Tuple
+import unicodedata
+from typing import Dict, List, Optional, Tuple
 
 import pandas as pd
 
@@ -63,15 +64,20 @@ def run_calculation_engine(user_data, excel_path):
         df_datos_entrada = all_sheets.get('Datos de Entrada')
         df_tarifas_consumo = all_sheets.get('Tarifas consumo')
         df_tarifas_inyeccion = all_sheets.get('Tarifas inyección')
-        df_resultados = all_sheets.get('Resultados')
-
         if df_datos_entrada is None:
             raise ValueError("La hoja 'Datos de Entrada' no está disponible en el Excel de soporte.")
 
         paneles_comerciales = pd.read_excel(excel_path, sheet_name='Paneles comerciales')
         paneles_genericos = pd.read_excel(excel_path, sheet_name='Paneles genéricos')
 
+        city_profile = resolve_city_profile(user_data, all_sheets)
         support_params = extract_support_parameters(df_datos_entrada)
+        support_params = apply_city_adjustments(
+            user_data,
+            support_params,
+            all_sheets,
+            city_profile,
+        )
 
         panel_marca = user_data.get('marcaPanel', 'GENERICOS')
         panel_potencia_deseada = to_numeric_safe(user_data.get('potenciaPanelDeseada', 450))
@@ -90,7 +96,15 @@ def run_calculation_engine(user_data, excel_path):
         emission_metrics = calculate_emission_metrics(energy_metrics, support_params)
         chart_data = build_chart_data(energy_metrics)
 
-        basic_report_table = extract_basic_table(df_resultados)
+        basic_report_table = build_basic_report_table(
+            user_data,
+            system_design,
+            energy_metrics,
+            economic_metrics,
+            tariffs,
+            emission_metrics,
+            support_params,
+        )
 
         technical_data = build_legacy_technical_data(system_design, energy_metrics, support_params)
         economic_data_legacy = build_legacy_economic_data(economic_metrics)
@@ -200,9 +214,17 @@ def extract_support_parameters(df_datos_entrada) -> Dict[str, float]:
     loss_wiring = to_numeric_safe(df_datos_entrada.iloc[138, 2])
     loss_inverter = to_numeric_safe(df_datos_entrada.iloc[140, 2])
 
-    total_losses_factor = sum(
-        [loss_fiam, loss_temp, loss_qual, loss_dirt, loss_mismatch, loss_wiring, loss_inverter]
-    )
+    loss_components = {
+        "loss_fiam": loss_fiam,
+        "loss_temp": loss_temp,
+        "loss_qual": loss_qual,
+        "loss_dirt": loss_dirt,
+        "loss_mismatch": loss_mismatch,
+        "loss_wiring": loss_wiring,
+        "loss_inverter": loss_inverter,
+    }
+
+    total_losses_factor = sum(loss_components.values())
     performance_ratio = max(0.0, 1 - total_losses_factor)
 
     vida_util_valor = to_numeric_safe(df_datos_entrada.iloc[190, 2], default=25)
@@ -216,12 +238,487 @@ def extract_support_parameters(df_datos_entrada) -> Dict[str, float]:
     return {
         "hsp_anual": hsp_anual,
         "performance_ratio": performance_ratio,
+        **loss_components,
         "project_lifetime_years": vida_util or 25,
         "investment_cost_kw_usd": costo_inversion_kw_usd,
         "maintenance_kw_year_usd": costo_mantenimiento_kw_year_usd,
         "usd_to_ars": tipo_cambio if tipo_cambio > 0 else 1.0,
         "emission_factor_tco2_per_mwh": 0.4658,
     }
+
+
+def resolve_city_profile(user_data: Dict, all_sheets: Dict[str, pd.DataFrame]) -> Optional[Dict]:
+    """Read the city catalog and locate the record for the requested city."""
+
+    df_ciudades = all_sheets.get('Ciudades')
+    if df_ciudades is None or df_ciudades.empty:
+        return None
+
+    catalog = _prepare_city_catalog(df_ciudades)
+    if catalog.empty:
+        return None
+
+    ciudad_info = user_data.get('ciudad') or {}
+    location = user_data.get('location') or {}
+    lat = location.get('lat')
+    lon = location.get('lng')
+
+    # Attempt to match by normalized name first.
+    target_name = ciudad_info.get('nombre')
+    matched_row = None
+    if target_name:
+        normalized = _normalize_text(target_name)
+        name_matches = catalog[_normalize_series(catalog['Ciudad']) == normalized]
+        if name_matches.empty:
+            name_matches = catalog[_normalize_series(catalog['Ciudad + Provincia']) == normalized]
+        if not name_matches.empty:
+            matched_row = _choose_row_by_location(name_matches, lat, lon)
+
+    if matched_row is None and lat is not None and lon is not None:
+        matched_row = _choose_row_by_location(catalog, lat, lon)
+
+    return matched_row
+
+
+def apply_city_adjustments(
+    user_data: Dict,
+    support_params: Dict[str, float],
+    all_sheets: Dict[str, pd.DataFrame],
+    city_profile: Optional[Dict],
+) -> Dict[str, float]:
+    """Adjust irradiance and losses according to the selected city."""
+
+    updated = dict(support_params)
+    updated['city_profile'] = city_profile
+
+    if not city_profile:
+        return updated
+
+    radiation_table = _parse_radiation_table(all_sheets.get('base de datos (3)'))
+    temperature_table = _parse_temperature_table(all_sheets.get('Temperaturas (2)'))
+
+    lat_lookup = _select_lookup_coordinate(city_profile, 'lat')
+    lon_lookup = _select_lookup_coordinate(city_profile, 'lon')
+
+    hsp_horizontal = None
+    if radiation_table is not None and lat_lookup is not None and lon_lookup is not None:
+        hsp_horizontal = _lookup_parameter_value(
+            radiation_table,
+            lat_lookup,
+            lon_lookup,
+            'ALLSKY_SFC_SW_DWN',
+        )
+
+    base_hsp = updated.get('hsp_anual')
+    if hsp_horizontal is None:
+        hsp_effective = base_hsp
+    else:
+        tilt_deg = to_numeric_safe(user_data.get('anguloInclinacion'), default=None)
+        if tilt_deg is None or tilt_deg == 0:
+            tilt_deg = abs(city_profile.get('lat') or 0)
+        tilt_factor = _compute_tilt_factor(city_profile.get('lat'), tilt_deg)
+        hsp_effective = hsp_horizontal * tilt_factor
+
+    if hsp_effective is not None:
+        updated['hsp_anual'] = hsp_effective
+
+    avg_temp = None
+    if temperature_table is not None and lat_lookup is not None and lon_lookup is not None:
+        avg_temp = _compute_average_temperature(temperature_table, lat_lookup, lon_lookup)
+
+    if avg_temp is not None and hsp_effective is not None:
+        loss_temp = max(
+            0.0,
+            TEMPERATURE_COEFFICIENT
+            * (avg_temp + IRRADIANCE_TEMPERATURE_GAIN * hsp_effective - TEMPERATURE_REFERENCE),
+        )
+        updated['loss_temp'] = loss_temp
+    else:
+        loss_temp = updated.get('loss_temp', 0.0)
+
+    total_losses = 0.0
+    for key in LOSS_COMPONENT_KEYS:
+        if key == 'loss_temp':
+            total_losses += loss_temp
+        else:
+            total_losses += updated.get(key, 0.0)
+    updated['performance_ratio'] = max(0.0, 1 - total_losses)
+
+    return updated
+
+
+def build_basic_report_table(
+    user_data: Dict,
+    system_design: Dict[str, float],
+    energy_metrics: Dict[str, float],
+    economic_metrics: Dict[str, float],
+    tariffs: Dict[str, float],
+    emission_metrics: Dict[str, float],
+    support_params: Dict[str, float],
+) -> List[List]:
+    """Assemble the summary table replicating the structure of the Excel sheet."""
+
+    table: List[List] = []
+
+    def make_row(label=None, value=None, unit=None):
+        row = [None] * BASIC_TABLE_COLUMNS
+        row[0] = label
+        row[1] = value
+        row[2] = unit
+        return row
+
+    def blank_row():
+        return [None] * BASIC_TABLE_COLUMNS
+
+    city_profile = support_params.get('city_profile') or {}
+    currency = tariffs.get('currency')
+
+    consumo_anual = energy_metrics.get('annualConsumptionKWh')
+    generacion_anual = energy_metrics.get('annualGenerationKWh')
+    autoconsumo_anual = energy_metrics.get('annualAutoconsumptionKWh')
+    inyeccion_anual = energy_metrics.get('annualInjectionKWh')
+    cobertura_pct = (energy_metrics.get('coverageRatio') or 0) * 100
+    autoconsumo_pct = (energy_metrics.get('selfConsumptionRatio') or 0) * 100
+    energia_red = energy_metrics.get('gridEnergyKWh')
+
+    panel_brand = system_design.get('panelBrand')
+    panel_model = system_design.get('panelModel')
+    panel_power = system_design.get('panelPowerW')
+    panel_count = system_design.get('panelCount')
+    superficie = system_design.get('requiredSurfaceM2')
+
+    inversor = user_data.get('inversor') or {}
+    potencia_inversor_kw = to_numeric_safe(inversor.get('potenciaNominal'), default=0)
+    potencia_inversor_w = potencia_inversor_kw * 1000 if potencia_inversor_kw else None
+    inversor_count = None
+    if potencia_inversor_kw:
+        inversor_count = max(
+            1,
+            int(
+                math.ceil(
+                    (system_design.get('installedCapacityKWp') or 0)
+                    / potencia_inversor_kw
+                )
+            ),
+        )
+
+    tarifa_consumo = tariffs.get('consumptionTariff')
+    tarifa_inyeccion = tariffs.get('injectionTariff')
+    gasto_pre = economic_metrics.get('preProjectAnnualCost')
+    costo_post = economic_metrics.get('postProjectAnnualCost')
+    mantenimiento = economic_metrics.get('maintenanceAnnualCost')
+    ingreso_inyeccion = economic_metrics.get('injectionRevenue')
+    ahorro_anual = economic_metrics.get('annualSavings')
+    inversion_inicial = economic_metrics.get('initialInvestment')
+    payback = economic_metrics.get('paybackYears')
+
+    costo_compra_red = energia_red * tarifa_consumo if energia_red and tarifa_consumo else 0.0
+
+    table.append(make_row("Resultado del dimensionamiento fotovoltaico"))
+    table.append(blank_row())
+    table.append(
+        make_row(
+            "Ciudad seleccionada",
+            city_profile.get('city_label')
+            or city_profile.get('city_name')
+            or (user_data.get('ciudad') or {}).get('nombre'),
+        )
+    )
+    table.append(
+        make_row(
+            "HSP anual estimado",
+            support_params.get('hsp_anual'),
+            "(kWh/kWp·día)",
+        )
+    )
+    table.append(blank_row())
+    table.append(make_row("Datos técnicos del dimensionamiento"))
+    table.append(make_row("• Consumo y generación"))
+    table.append(make_row("Consumo anual de energía eléctrica", consumo_anual, "(kWh/año)"))
+    table.append(make_row("Generación anual de energía eléctrica", generacion_anual, "(kWh/año)"))
+    table.append(make_row("Energía para autoconsumo", autoconsumo_anual, "(kWh/año)"))
+    table.append(make_row("Energía inyectada a la red", inyeccion_anual, "(kWh/año)"))
+    table.append(make_row("Energía comprada a la red", energia_red, "(kWh/año)"))
+    table.append(make_row("Cobertura del consumo con FV", cobertura_pct, "%"))
+    table.append(make_row("Autoconsumo de la generación FV", autoconsumo_pct, "%"))
+    table.append(blank_row())
+    table.append(make_row("• Detalles de la instalación"))
+    table.append(make_row("Marca seleccionada", panel_brand))
+    table.append(make_row("Modelo de panel", panel_model))
+    table.append(make_row("Potencia de paneles sugerida", panel_power, "W"))
+    table.append(make_row("Cantidad paneles necesarios", panel_count))
+    table.append(make_row("Superficie necesaria", superficie, "m²"))
+    table.append(blank_row())
+    table.append(make_row("• Inversor/es"))
+    table.append(make_row("Inversor/es sugerido/s", inversor.get('tipo')))
+    table.append(make_row("Potencia inversor nominal", potencia_inversor_w, "W"))
+    table.append(make_row("Cantidad de inversores", inversor_count))
+    table.append(blank_row())
+    table.append(
+        make_row("Vida útil del proyecto (años)", support_params.get('project_lifetime_years'), "años")
+    )
+    table.append(blank_row())
+    table.append(make_row("Resultados económicos"))
+    table.append(
+        make_row(
+            "Tarifa consumo de energía eléctrica",
+            tarifa_consumo,
+            f"{currency}/kWh" if currency else None,
+        )
+    )
+    table.append(
+        make_row(
+            "Tarifa inyección de energía eléctrica",
+            tarifa_inyeccion,
+            f"{currency}/kWh" if currency else None,
+        )
+    )
+    table.append(make_row("Gasto anual sin instalación FV", gasto_pre, currency))
+    table.append(make_row("Costo anual después del proyecto", costo_post, currency))
+    table.append(make_row("Costo de mantenimiento anual", mantenimiento, currency))
+    table.append(make_row("Costo anual de energía comprada a la red", costo_compra_red, currency))
+    table.append(make_row("Ingreso anual por inyección a la red", ingreso_inyeccion, currency))
+    table.append(make_row("Ahorro anual neto", ahorro_anual, currency))
+    table.append(make_row("Inversión inicial estimada", inversion_inicial, currency))
+    table.append(make_row("Payback estimado", payback, "años" if payback is not None else None))
+    table.append(blank_row())
+    table.append(make_row("Contribución a la mitigación del cambio climático"))
+    table.append(
+        make_row(
+            "Emisiones evitadas por año",
+            emission_metrics.get('avoidedTonsCO2PerYear'),
+            "tCO₂/año",
+        )
+    )
+    table.append(
+        make_row(
+            "Emisiones evitadas en la vida útil",
+            emission_metrics.get('avoidedTonsCO2Lifetime'),
+            "tCO₂",
+        )
+    )
+
+    return table
+
+
+LOSS_COMPONENT_KEYS = (
+    'loss_fiam',
+    'loss_temp',
+    'loss_qual',
+    'loss_dirt',
+    'loss_mismatch',
+    'loss_wiring',
+    'loss_inverter',
+)
+
+TEMPERATURE_COEFFICIENT = 0.004
+TEMPERATURE_REFERENCE = 25.0
+IRRADIANCE_TEMPERATURE_GAIN = 3.62
+BASIC_TABLE_COLUMNS = 11
+
+
+def _prepare_city_catalog(df_ciudades: pd.DataFrame) -> pd.DataFrame:
+    df = df_ciudades.copy()
+    header = df.iloc[0]
+    df = df[1:]
+    df.columns = header
+    expected_columns = [
+        'Ciudad + Provincia',
+        'Ciudad',
+        'Provincia',
+        'Latitud',
+        'Longitud',
+        'Latitud truncada',
+        'Longitud truncada',
+        'Control latitud',
+        'Control longitud',
+    ]
+    missing = [col for col in expected_columns if col not in df.columns]
+    if missing:
+        return pd.DataFrame()
+
+    catalog = df[expected_columns].copy()
+    for column in expected_columns[3:]:
+        catalog[column] = pd.to_numeric(catalog[column], errors='coerce')
+    catalog.dropna(subset=['Ciudad', 'Latitud', 'Longitud'], inplace=True)
+    return catalog
+
+
+def _normalize_text(value: Optional[str]) -> str:
+    if value is None:
+        return ''
+    text = unicodedata.normalize('NFKD', str(value))
+    text = ''.join(ch for ch in text if not unicodedata.combining(ch))
+    return text.upper().strip()
+
+
+def _normalize_series(series: pd.Series) -> pd.Series:
+    return series.astype(str).map(_normalize_text)
+
+
+def _choose_row_by_location(
+    catalog: pd.DataFrame,
+    lat: Optional[float],
+    lon: Optional[float],
+) -> Optional[Dict]:
+    if lat is None or lon is None or catalog.empty:
+        first_index = catalog.index[0]
+        return _city_profile_from_row(catalog.loc[first_index], first_index)
+
+    distances = (catalog['Latitud'] - float(lat)) ** 2 + (catalog['Longitud'] - float(lon)) ** 2
+    idx = distances.idxmin()
+    return _city_profile_from_row(catalog.loc[idx], idx)
+
+
+def _city_profile_from_row(row: pd.Series, idx) -> Dict:
+    def _clean(value):
+        if value is None:
+            return None
+        try:
+            if pd.isna(value):
+                return None
+        except TypeError:
+            pass
+        return value
+
+    return {
+        'row_index': int(idx) if idx is not None else None,
+        'city_label': _clean(row.get('Ciudad + Provincia')),
+        'city_name': _clean(row.get('Ciudad')),
+        'province': _clean(row.get('Provincia')),
+        'lat': _clean(row.get('Latitud')),
+        'lon': _clean(row.get('Longitud')),
+        'lat_trunc': _clean(row.get('Latitud truncada')),
+        'lon_trunc': _clean(row.get('Longitud truncada')),
+        'control_lat': _clean(row.get('Control latitud')),
+        'control_lon': _clean(row.get('Control longitud')),
+    }
+
+
+def _select_lookup_coordinate(city_profile: Dict, axis: str) -> Optional[float]:
+    for key in (f'{axis}_trunc', f'control_{axis}', axis):
+        value = city_profile.get(key)
+        if value is None:
+            continue
+        try:
+            if pd.isna(value):
+                continue
+        except TypeError:
+            pass
+        return _round_to_quarter(float(value))
+    return None
+
+
+def _round_to_quarter(value: float) -> float:
+    return round(value * 4) / 4
+
+
+def _compute_tilt_factor(latitude: Optional[float], tilt_deg: float) -> float:
+    if latitude is None:
+        return 1.0
+    latitude_rad = math.radians(abs(latitude))
+    tilt_rad = math.radians(tilt_deg)
+    denominator = math.cos(latitude_rad)
+    if abs(denominator) < 1e-6:
+        return 1.0
+    ratio = math.cos(latitude_rad - tilt_rad) / denominator
+    return max(ratio, 0.0)
+
+
+def _parse_radiation_table(df_raw: Optional[pd.DataFrame]) -> Optional[pd.DataFrame]:
+    if df_raw is None or df_raw.empty:
+        return None
+    data = df_raw.iloc[15:].copy()
+    if data.empty:
+        return None
+    data.columns = [
+        'lat',
+        'lon',
+        'parameter',
+        'key',
+        'jan',
+        'feb',
+        'mar',
+        'apr',
+        'may',
+        'jun',
+        'jul',
+        'aug',
+        'sep',
+        'oct',
+        'nov',
+        'dec',
+        'ann',
+    ]
+    data['lat'] = pd.to_numeric(data['lat'], errors='coerce')
+    data['lon'] = pd.to_numeric(data['lon'], errors='coerce')
+    data['ann'] = pd.to_numeric(data['ann'], errors='coerce')
+    data.dropna(subset=['lat', 'lon', 'parameter'], inplace=True)
+    return data
+
+
+def _parse_temperature_table(df_raw: Optional[pd.DataFrame]) -> Optional[pd.DataFrame]:
+    if df_raw is None or df_raw.empty:
+        return None
+    data = df_raw.iloc[15:].copy()
+    if data.empty:
+        return None
+    data.columns = [
+        'lat',
+        'lon',
+        'parameter',
+        'key',
+        'jan',
+        'feb',
+        'mar',
+        'apr',
+        'may',
+        'jun',
+        'jul',
+        'aug',
+        'sep',
+        'oct',
+        'nov',
+        'dec',
+        'ann',
+    ]
+    data['lat'] = pd.to_numeric(data['lat'], errors='coerce')
+    data['lon'] = pd.to_numeric(data['lon'], errors='coerce')
+    for month in ['jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul', 'aug', 'sep', 'oct', 'nov', 'dec', 'ann']:
+        data[month] = pd.to_numeric(data[month], errors='coerce')
+    data.dropna(subset=['lat', 'lon', 'parameter'], inplace=True)
+    return data
+
+
+def _lookup_parameter_value(
+    table: pd.DataFrame,
+    lat: float,
+    lon: float,
+    parameter: str,
+) -> Optional[float]:
+    subset = table[
+        (table['lat'] == lat) & (table['lon'] == lon) & (table['parameter'] == parameter)
+    ]
+    if subset.empty:
+        return None
+    value = subset['ann'].iloc[0]
+    return float(value) if pd.notna(value) else None
+
+
+def _compute_average_temperature(table: pd.DataFrame, lat: float, lon: float) -> Optional[float]:
+    max_row = table[
+        (table['lat'] == lat) & (table['lon'] == lon) & (table['parameter'] == 'T2M_MAX')
+    ]
+    min_row = table[
+        (table['lat'] == lat) & (table['lon'] == lon) & (table['parameter'] == 'T2M_MIN')
+    ]
+    if max_row.empty or min_row.empty:
+        return None
+    max_ann = max_row['ann'].iloc[0]
+    min_ann = min_row['ann'].iloc[0]
+    if pd.isna(max_ann) or pd.isna(min_ann):
+        return None
+    return float((max_ann + min_ann) / 2.0)
 
 
 def calculate_system_design(user_data: Dict, panel_data: Dict, support_params: Dict[str, float]) -> Dict[str, float]:
@@ -435,20 +932,6 @@ def build_chart_data(energy_metrics: Dict[str, float]) -> Dict[str, List[float]]
         "summer_daily_generation": generacion_diaria_verano,
     }
 
-
-def extract_basic_table(df_resultados) -> List[List]:
-    if df_resultados is None:
-        print("WARN: 'Resultados' sheet not found. Basic report table will be empty.")
-        return []
-
-    try:
-        basic_table_df = df_resultados.iloc[2:56, 1:12]
-        return basic_table_df.where(pd.notna(basic_table_df), None).values.tolist()
-    except Exception as table_error:  # pragma: no cover - defensive guard
-        print(f"WARN: Unable to extract basic report table: {table_error}")
-        return []
-
-
 def build_legacy_technical_data(
     system_design: Dict[str, float],
     energy_metrics: Dict[str, float],
@@ -463,6 +946,7 @@ def build_legacy_technical_data(
         "cantidad_paneles_necesarios": system_design.get('panelCount'),
         "superficie_necesaria": system_design.get('requiredSurfaceM2'),
         "vida_util_proyecto": support_params.get('project_lifetime_years'),
+        "hsp_anual": support_params.get('hsp_anual'),
     }
 
 

--- a/tests/test_engine_city.py
+++ b/tests/test_engine_city.py
@@ -1,0 +1,83 @@
+import json
+import unittest
+from copy import deepcopy
+from pathlib import Path
+from typing import Dict
+
+import pandas as pd
+
+from backend.engine import run_calculation_engine
+
+
+EXCEL_PATH = Path(__file__).resolve().parent.parent / 'backend' / 'Calculador Solar - web 06-24_con ayuda - modificaciones 2025_5.xlsx'
+PAYLOAD_PATH = Path(__file__).resolve().parent.parent / 'test_payload.json'
+
+
+class CitySensitivityTest(unittest.TestCase):
+    maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        with PAYLOAD_PATH.open('r', encoding='utf-8') as fh:
+            cls.base_payload = json.load(fh)
+
+        ciudades_df = pd.read_excel(EXCEL_PATH, sheet_name='Ciudades', header=None)
+        header = ciudades_df.iloc[0]
+        catalog = ciudades_df[1:].copy()
+        catalog.columns = header
+        cls.ciudades_catalog = catalog
+
+    def _configure_city(self, payload: Dict, city_name: str) -> Dict:
+        catalog = self.ciudades_catalog
+        city_rows = catalog[catalog['Ciudad'].astype(str).str.upper() == city_name.upper()]
+        if city_rows.empty:
+            self.fail(f'City {city_name} not found in catalog')
+        row = city_rows.iloc[0]
+        configured = deepcopy(payload)
+        configured['ciudad'] = {
+            'codigo': int(row.name) if isinstance(row.name, (int, float)) else None,
+            'nombre': city_name,
+        }
+        configured['location'] = {
+            'lat': float(row['Latitud']),
+            'lng': float(row['Longitud']),
+        }
+        return configured
+
+    def _run_for_city(self, city_name: str):
+        payload = self._configure_city(self.base_payload, city_name)
+        payload['userType'] = 'experto'
+        return run_calculation_engine(payload, EXCEL_PATH)
+
+    def _table_value(self, report: Dict, label: str):
+        for row in report['basic_report']['excel_table']:
+            if row and isinstance(row[0], str) and row[0].strip() == label:
+                return row[1]
+        return None
+
+    def test_city_selection_modifies_hsp_generation_and_table(self):
+        cordoba = self._run_for_city('CORDOBA')
+        ushuaia = self._run_for_city('USHUAIA')
+
+        self.assertNotEqual(
+            cordoba['technical_data']['hsp_anual'],
+            ushuaia['technical_data']['hsp_anual'],
+        )
+
+        self.assertNotEqual(
+            cordoba['energy']['annualGenerationKWh'],
+            ushuaia['energy']['annualGenerationKWh'],
+        )
+
+        cordoba_generation_row = self._table_value(
+            cordoba, 'Generación anual de energía eléctrica'
+        )
+        ushuaia_generation_row = self._table_value(
+            ushuaia, 'Generación anual de energía eléctrica'
+        )
+        self.assertNotEqual(cordoba_generation_row, ushuaia_generation_row)
+
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- derive the selected city from the Ciudades sheet and adjust irradiance/loss parameters before running the engine
- rebuild the basic report table from the Python calculations and expose the recalculated metrics such as HSP
- add a regression test ensuring that changing the city alters HSP, annual generation, and the basic report output

## Testing
- python -m unittest discover tests

------
https://chatgpt.com/codex/tasks/task_e_68dd03243a288327b77d0919c133c0a2