### PR TITLE
Persist selected city to Excel workbook

### DIFF
--- a/backend/backend.py
+++ b/backend/backend.py
@@ -6,6 +6,7 @@ import os
 import json
 import math
 from threading import Lock
+from openpyxl import load_workbook
 from . import engine
 
 excel_lock = Lock()
@@ -37,6 +38,43 @@ CONSUMOS_JSON_PATH = os.path.join(PROJECT_ROOT, 'consumos_electrodomesticos.json
 
 app = Flask(__name__, static_folder=PROJECT_ROOT, static_url_path='')
 CORS(app)  # Habilita CORS para permitir solicitudes desde el frontend
+
+
+# --- Ruta para actualizar una celda específica del Excel ---
+@app.route('/api/excel/update_cell', methods=['POST'])
+def update_excel_cell():
+    try:
+        payload = request.get_json(silent=True) or {}
+        raw_city_name = payload.get('ciudad', '')
+        # Manejar valores None o que no sean strings convirtiéndolos explícitamente
+        city_name = '' if raw_city_name is None else str(raw_city_name)
+
+        if not os.path.exists(EXCEL_FILE_PATH):
+            return jsonify({"success": False, "error": "Archivo Excel de configuración no encontrado."}), 404
+
+        with excel_lock:
+            workbook = load_workbook(EXCEL_FILE_PATH)
+            try:
+                worksheet = workbook['Datos de Entrada']
+            except KeyError:
+                return jsonify({"success": False, "error": "Hoja 'Datos de Entrada' no encontrada en el Excel."}), 500
+
+            worksheet['B7'] = city_name
+
+            try:
+                workbook.save(EXCEL_FILE_PATH)
+            except (OSError, IOError) as save_error:
+                return jsonify({"success": False, "error": f"No se pudo guardar el archivo Excel: {save_error}"}), 500
+
+        return jsonify({"success": True})
+
+    except (OSError, IOError) as io_error:
+        return jsonify({"success": False, "error": f"Error de E/S al actualizar el Excel: {io_error}"}), 500
+    except Exception as e:
+        import traceback
+        print(f"ERROR GENERAL en /api/excel/update_cell: {e}")
+        print(traceback.format_exc())
+        return jsonify({"success": False, "error": f"Error interno del servidor: {e}"}), 500
 
 
 # --- NUEVA RUTA: Para obtener la lista de electrodomésticos y sus consumos ---

--- a/calculador.js
+++ b/calculador.js
@@ -1642,6 +1642,36 @@ function extraerCiudadDeDireccion(direccion) {
     return null;
 }
 
+async function persistSelectedCityName(cityName) {
+    const locationDisplay = document.getElementById('location-display');
+    try {
+        const response = await fetch(API_BASE + '/excel/update_cell', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ ciudad: cityName || '' })
+        });
+
+        const data = await response.json().catch(() => ({}));
+
+        if (!response.ok || data.success === false) {
+            const errorMessage = (data && data.error) ? data.error : `Error del servidor: ${response.status}`;
+            throw new Error(errorMessage);
+        }
+
+        return true;
+    } catch (error) {
+        console.error('Error al persistir la ciudad seleccionada:', error);
+        if (locationDisplay) {
+            const warningSuffix = ' (No se pudo guardar en el servidor)';
+            if (!locationDisplay.textContent.includes(warningSuffix.trim())) {
+                locationDisplay.textContent = `${locationDisplay.textContent}${warningSuffix}`;
+            }
+            locationDisplay.style.backgroundColor = '#fbe9e7';
+        }
+        return false;
+    }
+}
+
 // --- Lógica del Mapa (EXISTENTE, CON PEQUEÑAS MEJORAS) ---
 
 function initMap() {
@@ -1706,17 +1736,21 @@ function initMap() {
                             locationDisplay.style.backgroundColor = '#fbe9e7'; // Red for failure
                         }
                     }
+
+                    await persistSelectedCityName(ciudadResult ? ciudadResult.nombre : '');
                 } else {
                     if (locationDisplay) {
                         locationDisplay.textContent = 'No se pudo identificar la ubicación. Intente de nuevo.';
                         locationDisplay.style.backgroundColor = '#fbe9e7';
                     }
                     userSelections.ciudad = { codigo: null, nombre: null };
+                    await persistSelectedCityName('');
                 }
             });
         } else {
             // Fallback if geocoder is not available
             userSelections.ciudad = { codigo: null, nombre: null };
+            persistSelectedCityName('');
         }
     });
 
@@ -1756,12 +1790,14 @@ function initMap() {
                         locationDisplay.textContent = `Ubicación seleccionada: ${ciudadResult.nombre}`;
                         locationDisplay.style.backgroundColor = '#e9f5e9'; // Green for success
                     }
+                    await persistSelectedCityName(ciudadResult.nombre);
                 } else {
                     userSelections.ciudad = { codigo: null, nombre: null };
                     if (locationDisplay) {
                         locationDisplay.textContent = 'No se pudo encontrar la ciudad en la base de datos.';
                         locationDisplay.style.backgroundColor = '#fbe9e7'; // Red for failure
                     }
+                    await persistSelectedCityName('');
                 }
             } else {
                 console.warn('Geocoder did not return a name.');
@@ -1770,6 +1806,7 @@ function initMap() {
                     locationDisplay.textContent = 'Dirección no válida.';
                     locationDisplay.style.backgroundColor = '#fbe9e7';
                 }
+                await persistSelectedCityName('');
             }
         }
     }).addTo(map);


### PR DESCRIPTION
## Summary
- add a Flask endpoint that writes the selected city into the Excel workbook with locking and error handling
- call the new endpoint from the map selection flows and warn the user if persistence fails

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd0ccab45c8327af546a3687676d62