### PR TITLE
Ensure Excel workbook closes after update

### DIFF
--- a/backend/backend.py
+++ b/backend/backend.py
@@ -53,20 +53,29 @@ def update_excel_cell():
             return jsonify({"success": False, "error": "Archivo Excel de configuración no encontrado."}), 404
 
         with excel_lock:
-            workbook = load_workbook(EXCEL_FILE_PATH)
+            workbook = None
             try:
-                worksheet = workbook['Datos de Entrada']
-            except KeyError:
-                return jsonify({"success": False, "error": "Hoja 'Datos de Entrada' no encontrada en el Excel."}), 500
+                workbook = load_workbook(EXCEL_FILE_PATH)
+                try:
+                    worksheet = workbook['Datos de Entrada']
+                except KeyError:
+                    return jsonify({"success": False, "error": "Hoja 'Datos de Entrada' no encontrada en el Excel."}), 500
 
-            worksheet['B7'] = city_name
+                worksheet['B7'] = city_name
 
-            try:
-                workbook.save(EXCEL_FILE_PATH)
-            except (OSError, IOError) as save_error:
-                return jsonify({"success": False, "error": f"No se pudo guardar el archivo Excel: {save_error}"}), 500
+                try:
+                    workbook.save(EXCEL_FILE_PATH)
+                except (OSError, IOError) as save_error:
+                    return jsonify({"success": False, "error": f"No se pudo guardar el archivo Excel: {save_error}"}), 500
 
-        return jsonify({"success": True})
+                return jsonify({"success": True})
+            finally:
+                if workbook is not None:
+                    try:
+                        workbook.close()
+                    except Exception:
+                        # Ignoramos el error de cierre para no sobreescribir la respuesta original.
+                        pass
 
     except (OSError, IOError) as io_error:
         return jsonify({"success": False, "error": f"Error de E/S al actualizar el Excel: {io_error}"}), 500


### PR DESCRIPTION
## Summary
- wrap the Excel update flow in a try/finally block so the workbook is always closed
- preserve the existing JSON responses and save behaviour when updating the city cell

## Testing
- python - <<'PY'
import json
from backend.backend import app

with open('test_payload.json', 'r', encoding='utf-8') as f:
    payload = json.load(f)

with app.test_client() as client:
    resp = client.post('/api/excel/update_cell', json={'ciudad': 'TEST CITY'})
    print('Update status:', resp.status_code, resp.get_json())
    informe = client.post('/api/generar_informe', json=payload)
    print('Informe status:', informe.status_code)
    data = informe.get_json()
    if isinstance(data, dict):
        print('Informe error?', data.get('error'))
        print('Informe keys sample:', list(data.keys())[:5])
    client.post('/api/excel/update_cell', json={'ciudad': 'BUENOS AIRES'})
PY

------
https://chatgpt.com/codex/tasks/task_e_68dd1333ae088327946534eac65d977f