### PR TITLE
Style basic report summary to match Excel layout

### DIFF
--- a/calculador.js
+++ b/calculador.js
@@ -2561,10 +2561,56 @@ function setupNavigationButtons() {
                 const informeFinal = await response.json();
                 console.log('Informe recibido del backend:', informeFinal);
 
-                // The userType from the backend's response is now the source of truth.
-                // The redundant and buggy overwriting of the value has been removed.
-
                 localStorage.setItem('informeSolar', JSON.stringify(informeFinal));
+
+                const backendUserType = typeof informeFinal.userType === 'string'
+                    ? informeFinal.userType.toLowerCase()
+                    : null;
+                const selectedUserType = typeof userSelections.userType === 'string'
+                    ? userSelections.userType.toLowerCase()
+                    : null;
+                const isBasicUser = backendUserType === 'basico' || selectedUserType === 'basico';
+
+                if (isBasicUser) {
+                    const resultadosContainer = document.getElementById('resultados-informe');
+                    const tableData = informeFinal?.basic_report?.excel_table || [];
+
+                    if (
+                        resultadosContainer &&
+                        window.BasicReportTableHelper &&
+                        typeof window.BasicReportTableHelper.renderTableInContainer === 'function'
+                    ) {
+                        resultadosContainer.innerHTML = '';
+                        resultadosContainer.classList.add('basic-report-summary-container');
+
+                        const helperOptions = {
+                            columnCount: 4,
+                            emptyMessage: 'No se encontraron datos para mostrar el informe básico detallado.',
+                        };
+
+                        const tableWrapper = document.createElement('div');
+                        tableWrapper.className = 'basic-report-table-wrapper';
+                        window.BasicReportTableHelper.renderTableInContainer(tableWrapper, tableData, helperOptions);
+                        resultadosContainer.appendChild(tableWrapper);
+
+                        const fullReportButton = document.createElement('button');
+                        fullReportButton.type = 'button';
+                        fullReportButton.textContent = 'Abrir informe completo';
+                        fullReportButton.className = 'basic-report-open-button';
+                        fullReportButton.addEventListener('click', () => {
+                            window.location.href = 'informe.html';
+                        });
+                        resultadosContainer.appendChild(fullReportButton);
+
+                        if (mapScreen) mapScreen.style.display = 'none';
+                        if (dataFormScreen) dataFormScreen.style.display = 'none';
+                        resultadosContainer.style.display = 'block';
+
+                        resultadosContainer.scrollIntoView({ behavior: 'smooth' });
+                        return;
+                    }
+                }
+
                 window.location.href = 'informe.html';
             } catch (error) {
                 console.error('Error al generar el informe:', error);

--- a/index.html
+++ b/index.html
@@ -1053,10 +1053,11 @@
     </div>
 
     <!-- ESTE ES EL CONTENEDOR DEL INFORME -->
-    <div id="resultados-informe" style="max-width:900px; margin: 2rem auto; background: #fffbe7; border-radius: 8px; padding: 2rem; font-size: 1.2rem; box-shadow: 0 1px 8px rgba(0,0,0,0.06);"></div>
+    <div id="resultados-informe" class="basic-report-summary-container"></div>
 
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
     <script src="https://unpkg.com/leaflet-control-geocoder/dist/Control.Geocoder.js"></script>
+    <script src="reportTableHelper.js?v=prod1" defer></script>
     <script src="calculador.js?v=prod2" defer></script>
 
     <footer>

--- a/informe.html
+++ b/informe.html
@@ -398,6 +398,7 @@
 
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js"></script>
+  <script src="reportTableHelper.js?v=prod1"></script>
   <script src="informe.js?v=prod1"></script>
 </body>
 </html>

--- a/informe.js
+++ b/informe.js
@@ -244,51 +244,153 @@ function renderBasicExcelTable(tableData) {
         return;
     }
 
+    if (window.BasicReportTableHelper && typeof window.BasicReportTableHelper.renderRows === 'function') {
+        window.BasicReportTableHelper.renderRows(tbody, tableData, { columnCount: 4 });
+        return;
+    }
+
+    // Fallback rendering in case the helper is not available for any reason.
     tbody.innerHTML = '';
 
     if (!Array.isArray(tableData) || tableData.length === 0) {
         const emptyRow = document.createElement('tr');
         const emptyCell = document.createElement('td');
-        emptyCell.colSpan = 11;
+        emptyCell.colSpan = 4;
         emptyCell.textContent = 'No se encontraron datos para mostrar el informe básico detallado.';
         emptyRow.appendChild(emptyCell);
         tbody.appendChild(emptyRow);
         return;
     }
 
-    const columnCount = Array.isArray(tableData[0]) ? tableData[0].length : 1;
+    const formatNumber = (value) => {
+        if (typeof value !== 'number' || !Number.isFinite(value)) {
+            return '';
+        }
+        if (Number.isInteger(value)) {
+            return value.toLocaleString('es-AR', { maximumFractionDigits: 0 });
+        }
+        const abs = Math.abs(value);
+        const fractionDigits = abs < 1 ? 3 : 2;
+        return value.toLocaleString('es-AR', {
+            minimumFractionDigits: fractionDigits,
+            maximumFractionDigits: fractionDigits,
+        });
+    };
+
+    const isUnit = (value) => typeof value === 'string' && /(%|US\$|U\$S|\$|d[oó]lares|tCO2|m2|kWh|W|años?|USD)/i.test(value);
 
     tableData.forEach((row) => {
-        const tr = document.createElement('tr');
-        const normalizedRow = Array.isArray(row) ? row : [row];
+        const rawCells = Array.isArray(row) ? row : [row];
+        const cleanedCells = rawCells.map((cell) => {
+            if (cell === null || cell === undefined) {
+                return null;
+            }
+            if (typeof cell === 'number') {
+                return Number.isFinite(cell) ? cell : null;
+            }
+            if (typeof cell === 'string') {
+                const trimmed = cell.trim();
+                return trimmed ? trimmed : null;
+            }
+            return null;
+        });
 
-        normalizedRow.forEach((cellValue) => {
-            const td = document.createElement('td');
-            let displayValue = '';
+        if (cleanedCells.every((cell) => cell === null)) {
+            return;
+        }
 
-            if (cellValue !== null && cellValue !== undefined) {
-                if (typeof cellValue === 'number') {
-                    if (Number.isFinite(cellValue)) {
-                        const roundedValue = Math.round(cellValue);
-                        displayValue = roundedValue.toLocaleString('es-AR', {
-                            minimumFractionDigits: 0,
-                            maximumFractionDigits: 0,
-                        });
-                    } else {
-                        displayValue = 'N/A';
-                    }
-                } else {
-                    displayValue = String(cellValue);
+        const label = typeof cleanedCells[0] === 'string' ? cleanedCells[0] : '';
+        const rest = cleanedCells.slice(1);
+        let value = '';
+        let unit = typeof cleanedCells[2] === 'string' ? cleanedCells[2] : '';
+        const notes = [];
+
+        if (typeof cleanedCells[1] === 'number') {
+            value = formatNumber(cleanedCells[1]);
+        } else if (typeof cleanedCells[1] === 'string') {
+            value = cleanedCells[1];
+        }
+
+        if (!value) {
+            const fallbackNumber = rest.find((cell) => typeof cell === 'number');
+            if (typeof fallbackNumber === 'number') {
+                value = formatNumber(fallbackNumber);
+            } else {
+                const fallbackText = rest.find((cell) => typeof cell === 'string' && !isUnit(cell));
+                if (fallbackText) {
+                    value = fallbackText;
                 }
             }
+        }
 
-            td.textContent = displayValue;
+        if (!unit) {
+            const fallbackUnit = rest.find((cell) => typeof cell === 'string' && isUnit(cell));
+            if (fallbackUnit) {
+                unit = fallbackUnit;
+            }
+        }
+
+        rest.forEach((cell) => {
+            if (!cell) {
+                return;
+            }
+            if (typeof cell === 'string' && !isUnit(cell) && cell !== value) {
+                notes.push(cell);
+            }
+        });
+
+        const note = notes.join('\n');
+        const tr = document.createElement('tr');
+
+        const addFullRow = (className, text) => {
+            tr.classList.add(className);
+            const td = document.createElement('td');
+            td.colSpan = 4;
+            td.textContent = text;
+            tr.appendChild(td);
+            tbody.appendChild(tr);
+        };
+
+        const normalizedLabel = (label || '').toLowerCase();
+
+        if (normalizedLabel.includes('resultado del dimensionamiento') ||
+            normalizedLabel.includes('datos técnicos') ||
+            normalizedLabel.includes('resultados económicos') ||
+            normalizedLabel.includes('contribución a la mitigación') ||
+            normalizedLabel.startsWith('•')) {
+            const className = normalizedLabel.includes('resultado del dimensionamiento')
+                ? 'table-main-title'
+                : normalizedLabel.startsWith('•')
+                    ? 'subsection-header'
+                    : 'section-header';
+            addFullRow(className, label);
+            return;
+        }
+
+        if (!label && note) {
+            addFullRow('note-row', note);
+            return;
+        }
+
+        if (!label && !note && !value && !unit) {
+            return;
+        }
+
+        const cells = [label || '', value || '', unit || '', note || ''];
+
+        cells.forEach((cellValue, index) => {
+            const td = document.createElement('td');
+            td.textContent = cellValue;
+            if (index === 3 && note) {
+                td.classList.add('note-cell');
+            }
             tr.appendChild(td);
         });
 
-        const cellsToPad = columnCount - tr.children.length;
-        for (let i = 0; i < cellsToPad; i += 1) {
-            tr.appendChild(document.createElement('td'));
+        if (label && (normalizedLabel.includes('saldo neto') || normalizedLabel.includes('inversión inicial') || normalizedLabel.includes('ahorro económico'))) {
+            tr.classList.add('highlight-row');
+        } else if (normalizedLabel.includes('efecto económico')) {
+            tr.classList.add('warning-row');
         }
 
         tbody.appendChild(tr);

--- a/reportTableHelper.js
+++ b/reportTableHelper.js
@@ -1,0 +1,298 @@
+(function (global) {
+  const DEFAULT_EMPTY_MESSAGE = 'No se encontraron datos para mostrar el informe básico detallado.';
+  const DEFAULT_COLUMN_COUNT = 4;
+  const UNIT_REGEX = /(%|US\$|U\$S|\$|d[oó]lares|tCO2|m2|kWh|W|años?|USD)/i;
+
+  function formatNumber(value) {
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+      return '';
+    }
+
+    if (Number.isInteger(value)) {
+      return value.toLocaleString('es-AR', { maximumFractionDigits: 0 });
+    }
+
+    const abs = Math.abs(value);
+    const fractionDigits = abs < 1 ? 3 : 2;
+    return value.toLocaleString('es-AR', {
+      minimumFractionDigits: fractionDigits,
+      maximumFractionDigits: fractionDigits,
+    });
+  }
+
+  function cleanCellValue(cellValue) {
+    if (cellValue === null || cellValue === undefined) {
+      return null;
+    }
+
+    if (typeof cellValue === 'number') {
+      return Number.isFinite(cellValue) ? cellValue : null;
+    }
+
+    if (typeof cellValue === 'string') {
+      const trimmed = cellValue.trim();
+      return trimmed ? trimmed : null;
+    }
+
+    return null;
+  }
+
+  function isUnit(value) {
+    if (typeof value !== 'string') {
+      return false;
+    }
+    return UNIT_REGEX.test(value);
+  }
+
+  function deriveRowClass(label, note) {
+    const safeLabel = (label || '').toLowerCase();
+    const safeNote = (note || '').toLowerCase();
+
+    if (!safeLabel && safeNote) {
+      return 'note-row';
+    }
+
+    if (safeLabel.includes('resultado del dimensionamiento')) {
+      return 'table-main-title';
+    }
+
+    if (
+      safeLabel.includes('datos técnicos') ||
+      safeLabel.includes('resultados económicos') ||
+      safeLabel.includes('contribución a la mitigación')
+    ) {
+      return 'section-header';
+    }
+
+    if (safeLabel.startsWith('•')) {
+      return 'subsection-header';
+    }
+
+    if (
+      safeLabel.includes('saldo neto') ||
+      safeLabel.includes('inversión inicial') ||
+      safeLabel.includes('ahorro económico')
+    ) {
+      return 'highlight-row';
+    }
+
+    if (safeLabel.includes('efecto económico')) {
+      return 'warning-row';
+    }
+
+    return null;
+  }
+
+  function normalizeRow(row, columnCount) {
+    const baseRow = Array.isArray(row) ? row : [row];
+    const cleaned = baseRow.map(cleanCellValue);
+
+    const hasMeaningfulContent = cleaned.some((cell) => {
+      if (cell === null) {
+        return false;
+      }
+      if (typeof cell === 'number') {
+        return true;
+      }
+      return typeof cell === 'string' && cell.trim() !== '';
+    });
+
+    if (!hasMeaningfulContent) {
+      return null;
+    }
+
+    const label = typeof cleaned[0] === 'string' ? cleaned[0] : '';
+    const rest = cleaned.slice(1);
+    const usedRestIndices = new Set();
+
+    let value = '';
+    if (typeof cleaned[1] === 'number') {
+      value = formatNumber(cleaned[1]);
+      usedRestIndices.add(0);
+    } else if (typeof cleaned[1] === 'string') {
+      value = cleaned[1];
+      usedRestIndices.add(0);
+    }
+
+    if (!value) {
+      for (let i = 0; i < rest.length; i += 1) {
+        const cell = rest[i];
+        if (typeof cell === 'number') {
+          value = formatNumber(cell);
+          usedRestIndices.add(i);
+          break;
+        }
+        if (!value && typeof cell === 'string' && !isUnit(cell)) {
+          value = cell;
+          usedRestIndices.add(i);
+          break;
+        }
+      }
+    }
+
+    let unit = typeof cleaned[2] === 'string' ? cleaned[2] : '';
+    if (unit) {
+      usedRestIndices.add(1);
+    }
+
+    if (!unit) {
+      for (let i = 0; i < rest.length; i += 1) {
+        if (usedRestIndices.has(i)) {
+          continue;
+        }
+        const cell = rest[i];
+        if (typeof cell === 'string' && isUnit(cell)) {
+          unit = cell;
+          usedRestIndices.add(i);
+          break;
+        }
+      }
+    }
+
+    const noteParts = [];
+    for (let i = 0; i < rest.length; i += 1) {
+      if (usedRestIndices.has(i)) {
+        continue;
+      }
+      const cell = rest[i];
+      if (typeof cell === 'string' && cell.trim() !== '') {
+        noteParts.push(cell);
+        usedRestIndices.add(i);
+      }
+    }
+
+    const note = noteParts.join('\n');
+    const rowClass = deriveRowClass(label, note);
+
+    if (!label && !note && !value && !unit) {
+      return null;
+    }
+
+    if (rowClass === 'table-main-title' || rowClass === 'section-header' || rowClass === 'subsection-header') {
+      const fullText = label || note;
+      return {
+        type: 'full',
+        className: rowClass,
+        cells: [fullText],
+      };
+    }
+
+    if (rowClass === 'note-row') {
+      const fullText = note || label;
+      return {
+        type: 'full',
+        className: 'note-row',
+        cells: [fullText],
+      };
+    }
+
+    const resolvedColumns = columnCount || DEFAULT_COLUMN_COUNT;
+    const cells = new Array(resolvedColumns).fill('');
+    cells[0] = label || '';
+    cells[1] = value || '';
+    cells[2] = unit || '';
+    if (note) {
+      cells[3] = note;
+    }
+
+    return {
+      type: 'standard',
+      className: rowClass,
+      cells,
+      noteColumnIndex: note ? 3 : null,
+    };
+  }
+
+  function renderRows(tbody, tableData, options = {}) {
+    if (!tbody) {
+      return { rendered: false };
+    }
+
+    const { emptyMessage = DEFAULT_EMPTY_MESSAGE } = options;
+    const resolvedColumnCount = options.columnCount && options.columnCount > 0
+      ? options.columnCount
+      : DEFAULT_COLUMN_COUNT;
+
+    tbody.innerHTML = '';
+
+    if (!Array.isArray(tableData) || tableData.length === 0) {
+      const emptyRow = document.createElement('tr');
+      const emptyCell = document.createElement('td');
+      emptyCell.colSpan = resolvedColumnCount;
+      emptyCell.textContent = emptyMessage;
+      emptyRow.appendChild(emptyCell);
+      tbody.appendChild(emptyRow);
+      return { rendered: true, rows: 0 };
+    }
+
+    const processedRows = tableData
+      .map((row) => normalizeRow(row, resolvedColumnCount))
+      .filter((row) => row !== null);
+
+    if (processedRows.length === 0) {
+      const emptyRow = document.createElement('tr');
+      const emptyCell = document.createElement('td');
+      emptyCell.colSpan = resolvedColumnCount;
+      emptyCell.textContent = emptyMessage;
+      emptyRow.appendChild(emptyCell);
+      tbody.appendChild(emptyRow);
+      return { rendered: true, rows: 0 };
+    }
+
+    processedRows.forEach((row) => {
+      const tr = document.createElement('tr');
+      if (row.className) {
+        tr.classList.add(row.className);
+      }
+
+      if (row.type === 'full') {
+        const td = document.createElement('td');
+        td.colSpan = resolvedColumnCount;
+        td.textContent = row.cells[0] || '';
+        tr.appendChild(td);
+      } else {
+        row.cells.forEach((cellValue, cellIndex) => {
+          const td = document.createElement('td');
+          if (cellValue) {
+            td.textContent = cellValue;
+          }
+          if (row.noteColumnIndex === cellIndex) {
+            td.classList.add('note-cell');
+          }
+          tr.appendChild(td);
+        });
+      }
+
+      tbody.appendChild(tr);
+    });
+
+    return { rendered: true, rows: processedRows.length };
+  }
+
+  function renderTableInContainer(container, tableData, options = {}) {
+    if (!container) {
+      return { rendered: false };
+    }
+
+    container.innerHTML = '';
+
+    const table = document.createElement('table');
+    table.className = options.tableClass || 'report-table basic-excel-table';
+    const tbody = document.createElement('tbody');
+
+    if (options.tbodyId) {
+      tbody.id = options.tbodyId;
+    }
+
+    table.appendChild(tbody);
+    container.appendChild(table);
+
+    const renderResult = renderRows(tbody, tableData, options);
+    return { rendered: renderResult.rendered, rows: renderResult.rows, table, tbody };
+  }
+
+  global.BasicReportTableHelper = {
+    renderRows,
+    renderTableInContainer,
+  };
+})(typeof window !== 'undefined' ? window : this);

--- a/styles.css
+++ b/styles.css
@@ -1065,3 +1065,124 @@ footer {
 .acordeon-items .form-group-energia:last-child {
   margin-bottom: 0;
 }
+
+/* Shared styling for the tabla del informe básico en el calculador */
+.basic-report-summary-container {
+  display: none;
+  max-width: 960px;
+  margin: 2rem auto;
+  padding: 2rem;
+  background: #ffffff;
+  border: 2px solid #1f497d;
+  border-radius: 10px;
+  box-shadow: 0 8px 20px rgba(15, 46, 99, 0.08);
+}
+
+.basic-report-table-wrapper {
+  overflow-x: auto;
+  margin-top: 1.5rem;
+}
+
+.basic-report-table-wrapper .basic-excel-table {
+  margin-bottom: 0;
+}
+
+.basic-excel-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 1rem;
+  background: #ffffff;
+  border: 2px solid #1f497d;
+  box-shadow: 0 4px 12px rgba(17, 52, 105, 0.06);
+  margin-bottom: 1.5rem;
+}
+
+.basic-excel-table td {
+  border: 1px solid #b4c6e7;
+  padding: 12px 16px;
+  color: #1f2a44;
+}
+
+.basic-excel-table td:first-child {
+  font-weight: 600;
+  width: 45%;
+  color: #1f497d;
+}
+
+.basic-excel-table td:nth-child(2) {
+  text-align: right;
+  font-weight: 600;
+}
+
+.basic-excel-table td:nth-child(3) {
+  text-align: center;
+  font-weight: 500;
+  width: 140px;
+}
+
+.basic-excel-table td.note-cell {
+  white-space: pre-line;
+  font-size: 0.95rem;
+  color: #1f2a44;
+}
+
+.basic-excel-table tr.table-main-title td {
+  background: #1f497d;
+  color: #ffffff;
+  font-weight: 700;
+  font-size: 1.25rem;
+  text-align: center;
+  border-color: #1f497d;
+}
+
+.basic-excel-table tr.section-header td {
+  background: #dae3f3;
+  color: #1f497d;
+  font-weight: 700;
+}
+
+.basic-excel-table tr.subsection-header td {
+  background: #e9eff9;
+  color: #1f497d;
+  font-weight: 600;
+}
+
+.basic-excel-table tr.highlight-row td {
+  background: #fff2cc;
+  color: #7f4e00;
+  font-weight: 600;
+}
+
+.basic-excel-table tr.warning-row td {
+  background: #fde9d9;
+  color: #9c2f13;
+  font-style: italic;
+}
+
+.basic-excel-table tr.note-row td {
+  background: #f7f9fc;
+  color: #1f2a44;
+  font-style: italic;
+}
+
+.basic-report-open-button {
+  margin-top: 1.5rem;
+  padding: 0.75rem 1.75rem;
+  background-color: #1f497d;
+  color: #ffffff;
+  border: none;
+  border-radius: 6px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease-in-out, transform 0.2s ease-in-out;
+}
+
+.basic-report-open-button:hover {
+  background-color: #17345d;
+  transform: translateY(-1px);
+}
+
+.basic-report-open-button:active {
+  transform: translateY(0);
+}


### PR DESCRIPTION
## Summary
- Revise the shared basic report table helper to normalize values, classify section rows, and build four-column output that mirrors the Excel layout
- Populate the calculator summary container with the styled table and reuse the helper from informe.js with a richer fallback renderer
- Introduce dedicated styles for the summary container, Excel-like table sections, and the action button so the in-app preview matches the provided format

## Testing
- not run (frontend changes only)


------
https://chatgpt.com/codex/tasks/task_e_68dd7149dfd48327b1cda5822a4fa806