### PR TITLE
feat: Replace map geocoder with city search input

### DIFF
--- a/calculador.js
+++ b/calculador.js
@@ -815,26 +815,28 @@ async function initCitySearch() {
             dataList.appendChild(option);
         });
 
-        // Usar el evento 'blur' que se dispara cuando el campo pierde el foco
-        searchInput.addEventListener('blur', async (e) => {
-            const selectedName = e.target.value.trim().toLowerCase();
-            const ciudadSeleccionada = searchInput.ciudadesData.find(c => c.nombre.trim().toLowerCase() === selectedName);
+        // Usar el evento 'change' que es más robusto para datalists
+        searchInput.addEventListener('change', async (e) => {
+            const selectedName = e.target.value.trim();
+            const ciudadSeleccionada = searchInput.ciudadesData.find(
+                c => c.nombre.trim().toLowerCase() === selectedName.toLowerCase()
+            );
 
             if (ciudadSeleccionada) {
                 console.log('Ciudad seleccionada desde el buscador:', ciudadSeleccionada);
-
-                // Actualizar el estado global
                 userSelections.ciudad = {
                     codigo: ciudadSeleccionada.codigo,
                     nombre: ciudadSeleccionada.nombre
                 };
-
-                // Actualizar la UI
                 locationDisplay.textContent = `Ubicación seleccionada: ${ciudadSeleccionada.nombre}`;
                 locationDisplay.style.backgroundColor = '#e9f5e9';
-
-                // Persistir el cambio en el backend (Excel)
                 await persistSelectedCityName(ciudadSeleccionada.nombre);
+            } else {
+                console.warn(`La ciudad '${selectedName}' no se encontró en la lista.`);
+                userSelections.ciudad = { codigo: null, nombre: null };
+                locationDisplay.textContent = 'Ciudad no válida. Por favor, seleccione una de la lista.';
+                locationDisplay.style.backgroundColor = '#fbe9e7';
+                await persistSelectedCityName('');
             }
         });
 
@@ -1728,6 +1730,66 @@ async function persistSelectedCityName(cityName) {
         return false;
     }
 }
+
+// --- Nueva función para implementar el buscador de ciudades ---
+async function initCitySearch() {
+    const searchInput = document.getElementById('ciudad-search-input');
+    const dataList = document.getElementById('ciudades-list');
+    const locationDisplay = document.getElementById('location-display');
+
+    if (!searchInput || !dataList || !locationDisplay) {
+        console.error("No se encontraron los elementos para el buscador de ciudades.");
+        return;
+    }
+
+    try {
+        const response = await fetch(API_BASE + '/ciudades');
+        if (!response.ok) {
+            throw new Error(`Error HTTP: ${response.status}`);
+        }
+        const ciudades = await response.json();
+
+        // Guardar la lista para referencia en el evento
+        searchInput.ciudadesData = ciudades;
+
+        // Rellenar el datalist
+        ciudades.forEach(ciudad => {
+            const option = document.createElement('option');
+            option.value = ciudad.nombre;
+            dataList.appendChild(option);
+        });
+
+        // Usar el evento 'change' que es más robusto para datalists
+        searchInput.addEventListener('change', async (e) => {
+            const selectedName = e.target.value.trim();
+            const ciudadSeleccionada = searchInput.ciudadesData.find(
+                c => c.nombre.trim().toLowerCase() === selectedName.toLowerCase()
+            );
+
+            if (ciudadSeleccionada) {
+                console.log('Ciudad seleccionada desde el buscador:', ciudadSeleccionada);
+                userSelections.ciudad = {
+                    codigo: ciudadSeleccionada.codigo,
+                    nombre: ciudadSeleccionada.nombre
+                };
+                locationDisplay.textContent = `Ubicación seleccionada: ${ciudadSeleccionada.nombre}`;
+                locationDisplay.style.backgroundColor = '#e9f5e9';
+                await persistSelectedCityName(ciudadSeleccionada.nombre);
+            } else {
+                console.warn(`La ciudad '${selectedName}' no se encontró en la lista.`);
+                userSelections.ciudad = { codigo: null, nombre: null };
+                locationDisplay.textContent = 'Ciudad no válida. Por favor, seleccione una de la lista.';
+                locationDisplay.style.backgroundColor = '#fbe9e7';
+                await persistSelectedCityName('');
+            }
+        });
+
+    } catch (error) {
+        console.error("Error al cargar la lista de ciudades:", error);
+        // Opcional: mostrar un mensaje de error al usuario
+    }
+}
+
 
 // --- Lógica del Mapa (EXISTENTE, CON PEQUEÑAS MEJORAS) ---
 
@@ -2681,8 +2743,8 @@ function setupSidebarNavigation() {
 // --- INIT principal (Se ejecuta al cargar el DOM) (EXISTENTE, MODIFICADO) ---
 document.addEventListener('DOMContentLoaded', async () => {
     try {
-        // Inicializa el mapa primero, ya que es la primera pantalla.
-        initMap();
+        // La inicialización del mapa se ha deshabilitado para priorizar el buscador de ciudades.
+        // initMap();
 
         // Inicializa el nuevo buscador de ciudades
         initCitySearch();

--- a/index.html
+++ b/index.html
@@ -652,16 +652,16 @@
                 <h2 style="text-align: center; font-family: var(--font-heading); font-size: 1.4rem; color: #555; margin-bottom: 1rem;">
                     ¿Dónde será la instalación?
                 </h2>
-                <p class="help-text">Marcá el punto en el mapa donde vas a realizar la instalación o ingresá tu dirección completa.</p>
+                <p class="help-text">Busca y selecciona tu ciudad en la lista para comenzar.</p>
                 <div class="form-group" id="ciudad-search-container" style="width: 100%; max-width: 700px; margin-bottom: 1rem;">
-                    <label for="ciudad-search-input" style="display: block; font-weight: 500; margin-bottom: 0.5rem;">O busca tu ciudad en la lista:</label>
+                    <label for="ciudad-search-input" style="display: block; font-weight: 500; margin-bottom: 0.5rem;">Buscá tu ciudad:</label>
                     <input type="text" id="ciudad-search-input" list="ciudades-list" class="form-control" placeholder="Escribe el nombre de tu ciudad...">
                     <datalist id="ciudades-list">
                         <!-- Opciones se cargarán aquí -->
                     </datalist>
                 </div>
-                <div id="map"></div>
-                <div id="geocoder-container"></div>
+                <div id="map" style="display: none;"></div>
+                <div id="geocoder-container" style="display: none;"></div>
                 <div id="location-display" style="margin-top: 1rem; padding: 0.5rem 1rem; background-color: #e9f5e9; border-radius: 6px; border: 1px solid var(--color-secondary); text-align: center; font-weight: 500; color: #333;">
                     Ubicación no seleccionada
                 </div>

--- a/jules-scratch/verification/verify_city_search.py
+++ b/jules-scratch/verification/verify_city_search.py
@@ -1,5 +1,5 @@
-import re
 from playwright.sync_api import sync_playwright, expect
+import re
 
 def run(playwright):
     browser = playwright.chromium.launch(headless=True)
@@ -8,31 +8,44 @@ def run(playwright):
 
     try:
         # 1. Navigate to the application
-        page.goto("http://localhost:8000")
+        page.goto("http://127.0.0.1:8000", timeout=30000)
+        print("Navigated to the page.")
 
-        # 2. Locate the new city search input field
-        search_input = page.locator("#ciudad-search-input")
-        expect(search_input).to_be_visible(timeout=10000)
+        # 2. Locate the city search input
+        city_input = page.locator("#ciudad-search-input")
+        expect(city_input).to_be_visible(timeout=10000)
+        print("City input is visible.")
 
-        # 3. Type a city name and press Enter to confirm selection
         city_to_select = "Olavarría"
-        search_input.type(city_to_select, delay=100) # Type slowly to allow datalist to appear
-        search_input.press("Enter")
 
-        # 4. Assert that the location display has updated
+        # 3. Fill the input with the exact city name
+        city_input.fill(city_to_select)
+        print(f"Filled input with '{city_to_select}'.")
+
+        # 4. Trigger the 'change' event by blurring the input.
+        # Clicking another element is a reliable way to do this.
+        page.locator("body").click()
+        print("Clicked body to blur input and trigger change event.")
+
+        # Add a small delay to ensure the event has time to be processed.
+        page.wait_for_timeout(2000)
+
+        # 5. Verify the location display has updated
         location_display = page.locator("#location-display")
-        expect(location_display).to_contain_text(f"Ubicación seleccionada: {city_to_select}", timeout=10000)
 
-        # 5. Take a screenshot for visual confirmation
-        page.screenshot(path="jules-scratch/verification/city_search_verification.png")
-        print("✅ City search verification successful. Screenshot saved.")
+        # Use a regular expression to make the text check more flexible
+        expect(location_display).to_have_text(re.compile(city_to_select), timeout=15000)
+        print("Location display updated correctly.")
+
+        # 6. Take a screenshot for visual confirmation
+        screenshot_path = "jules-scratch/verification/verification.png"
+        page.screenshot(path=screenshot_path)
+        print(f"Screenshot saved to {screenshot_path}")
 
     except Exception as e:
-        print(f"❌ An error occurred during verification: {e}")
-        page.screenshot(path="jules-scratch/verification/city_search_failure.png")
-
+        print(f"An error occurred: {e}")
     finally:
-        # 6. Clean up
+        # Clean up
         context.close()
         browser.close()
 


### PR DESCRIPTION
This commit replaces the map-based location selector with a city search input.

- The `index.html` file has been updated to hide the map and geocoder, and the instructional text has been updated to guide the user to the new city search functionality.
- The `calculador.js` file has been updated to include a new `initCitySearch` function that fetches city data from the backend and populates a datalist.
- The `DOMContentLoaded` event listener has been updated to call the new `initCitySearch` function and disable the old map initialization.
- The `change` event is used for the city search input to ensure reliable event handling.
- The backend already had the necessary `/api/ciudades` endpoint, so no changes were required there.