### PR TITLE
Allow trailing slash for ciudades route

### DIFF
--- a/backend/backend.py
+++ b/backend/backend.py
@@ -116,6 +116,7 @@ CORS(app)  # Habilita CORS para permitir solicitudes desde el frontend
 
 
 @app.route('/api/ciudades', methods=['GET'])
+@app.route('/api/ciudades/', methods=['GET'])
 def obtener_ciudades():
     try:
         df = pd.read_excel(


### PR DESCRIPTION
## Summary
- add a second route decorator so /api/ciudades accepts requests with or without a trailing slash

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691caf254878832781201eece5c9d89f)